### PR TITLE
[bir][BIRToLLVM] Use `LLVMFuncOp::create` instead of `rewriter.create`

### DIFF
--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -427,11 +427,7 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
       rewriter.setInsertionPointToStart(module.getBody());
       auto funcType = LLVM::LLVMFunctionType::get(
           LLVM::LLVMPointerType::get(ctx), mlir::IntegerType::get(ctx, 64));
-      OperationState funcState(UnknownLoc::get(ctx),
-                               LLVM::LLVMFuncOp::getOperationName());
-      LLVM::LLVMFuncOp::build(rewriter, funcState, kGCAlloc,
-                              funcType);
-      rewriter.create(funcState);
+      LLVM::LLVMFuncOp::create(rewriter, loc, kGCAlloc, funcType);
     }
 
     auto i64Type = mlir::IntegerType::get(ctx, 64);


### PR DESCRIPTION
We should be consistent in using `{Op}::create`. I also find the `rewriter.create` function to be crossed out by clangd. I don't really understand why, but I believe using `{Op}::create` is preferable.