### PR TITLE
[birgen] Implement C++ rewrite

### DIFF
--- a/bin/belalang/BUILD.bazel
+++ b/bin/belalang/BUILD.bazel
@@ -29,6 +29,8 @@ cc_binary(
         "//lib:Lexer",
         "//lib:AST",
         "//lib:Diag",
+        "//lib:BIRGen",
         "//include:Version",
+        "//bir",
     ],
 )

--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -1,5 +1,6 @@
 #include "belalang/AST/Parser.h"
 #include "belalang/AST/ASTDumper.h"
+#include "belalang/BIRGen/BIRGen.h"
 #include "belalang/Lexer/Lexer.h"
 #include "belalang/Diag/Diag.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -60,6 +61,8 @@ int build(muopt::Parser &parser) {
         emit = EmitTarget::Tokens;
       if (value == "ast")
         emit = EmitTarget::Ast;
+      if (value == "bir")
+        emit = EmitTarget::Bir;
     }
     if (arg.has_value() && arg->is_plain()) {
       source = arg->as_str();
@@ -119,6 +122,28 @@ int build(muopt::Parser &parser) {
       dumper.visitProgram(prog);
     }
 
+    return parser.hadError() ? 1 : 0;
+  }
+
+  if (emit == EmitTarget::Bir) {
+    lexer::Lexer lexer(src, diagEngine);
+
+    ast::ASTContext astCtx;
+    ast::Parser parser(lexer, astCtx, diagEngine);
+
+    ast::Program *prog = parser.parseProgram();
+    if (!prog)
+      return parser.hadError() ? 1 : 0;
+
+    birgen::BIRGen birgen(diagEngine);
+    birgen.generateProgram(prog);
+
+    if (!birgen.runLoweringPipeline()) {
+      std::cerr << "error: BIR lowering pipeline failed\n";
+      return 1;
+    }
+
+    std::cout << birgen.dumpToString() << "\n";
     return parser.hadError() ? 1 : 0;
   }
 

--- a/birgen/BUILD.bazel
+++ b/birgen/BUILD.bazel
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "birgen-cc",
-    srcs = ["BIRGen.cpp"],
+    srcs = ["CxxBIRGen.cpp"],
     deps = [
         "//bir",
         "//include:BIRGen",

--- a/birgen/CxxBIRGen.cpp
+++ b/birgen/CxxBIRGen.cpp
@@ -1,4 +1,4 @@
-#include "belalang/BIRGen/BIRGen.h"
+#include "belalang/BIRGen/CxxBIRGen.h"
 #include "belalang/BIR/IR/BIR.h"
 #include "belalang/BIR/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -15,7 +15,7 @@ namespace birgen {
 
 #include "belalang/BIRGen/Bindings.cpp.inc"
 
-BIRGen::BIRGen() : builder(&context), loc(builder.getUnknownLoc()) {
+CxxBIRGen::CxxBIRGen() : builder(&context), loc(builder.getUnknownLoc()) {
   // Load dialects.
   mlir::DialectRegistry registry;
   registry.insert<bir::BIRDialect, mlir::LLVM::LLVMDialect>();
@@ -34,7 +34,7 @@ BIRGen::BIRGen() : builder(&context), loc(builder.getUnknownLoc()) {
   builder.setInsertionPointToStart(entry);
 }
 
-mlir::Type BIRGen::mapType(TypeKind ty) {
+mlir::Type CxxBIRGen::mapType(TypeKind ty) {
   if (ty == TypeKind::String) {
     return bir::StringType::get(&context);
   } else if (ty == TypeKind::Int) {
@@ -48,7 +48,7 @@ mlir::Type BIRGen::mapType(TypeKind ty) {
   }
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_constant_int(int64_t val) {
+std::unique_ptr<BIRValue> CxxBIRGen::build_constant_int(int64_t val) {
   auto type = builder.getType<bir::IntType>();
   llvm::APInt value(64, val);
   auto attr = bir::IntegerAttr::get(&context, type, value);
@@ -56,7 +56,7 @@ std::unique_ptr<BIRValue> BIRGen::build_constant_int(int64_t val) {
   return std::make_unique<BIRValue>(op.getResult());
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_constant_float(double val) {
+std::unique_ptr<BIRValue> CxxBIRGen::build_constant_float(double val) {
   auto type = builder.getType<bir::FloatType>();
   llvm::APFloat value(val);
   auto attr = bir::FloatAttr::get(&context, type, value);
@@ -64,7 +64,7 @@ std::unique_ptr<BIRValue> BIRGen::build_constant_float(double val) {
   return std::make_unique<BIRValue>(op.getResult());
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_constant_string(rust::Str val) {
+std::unique_ptr<BIRValue> CxxBIRGen::build_constant_string(rust::Str val) {
   auto type = builder.getType<bir::StringType>();
   llvm::StringRef value(val.data(), val.size());
   auto attr = bir::StringAttr::get(&context, type, value);
@@ -72,7 +72,7 @@ std::unique_ptr<BIRValue> BIRGen::build_constant_string(rust::Str val) {
   return std::make_unique<BIRValue>(op.getResult());
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_constant_bool(bool val) {
+std::unique_ptr<BIRValue> CxxBIRGen::build_constant_bool(bool val) {
   auto type = builder.getType<bir::BoolType>();
   auto attr = bir::BoolAttr::get(&context, type, val);
   auto op = bir::ConstantOp::create(builder, loc, type, attr);
@@ -99,7 +99,7 @@ std::unique_ptr<BIRValue> build_binop_cmp_impl(mlir::OpBuilder &builder,
 }
 
 std::unique_ptr<BIRValue>
-BIRGen::build_binop(BinOpKind kind, const BIRValue &lhs, const BIRValue &rhs) {
+CxxBIRGen::build_binop(BinOpKind kind, const BIRValue &lhs, const BIRValue &rhs) {
   switch (kind) {
   case BinOpKind::Add:
     return build_binop_impl<bir::AddOp>(builder, loc, lhs, rhs);
@@ -128,7 +128,7 @@ BIRGen::build_binop(BinOpKind kind, const BIRValue &lhs, const BIRValue &rhs) {
   }
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_var_declare(const BIRValue &v,
+std::unique_ptr<BIRValue> CxxBIRGen::build_var_declare(const BIRValue &v,
                                                     rust::Str name) {
   auto nakedType = v.getValue().getType();
   auto refType = bir::RefType::get(&context, nakedType);
@@ -137,7 +137,7 @@ std::unique_ptr<BIRValue> BIRGen::build_var_declare(const BIRValue &v,
   return std::make_unique<BIRValue>(op.getResult());
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_var_declare_ty(TypeKind v,
+std::unique_ptr<BIRValue> CxxBIRGen::build_var_declare_ty(TypeKind v,
                                                        rust::Str name) {
   mlir::Type ty = mapType(v);
 
@@ -147,13 +147,13 @@ std::unique_ptr<BIRValue> BIRGen::build_var_declare_ty(TypeKind v,
   return std::make_unique<BIRValue>(op.getResult());
 }
 
-void BIRGen::build_var_store(const BIRValue &v, const BIRValue &ref) {
+void CxxBIRGen::build_var_store(const BIRValue &v, const BIRValue &ref) {
   auto src = v.getValue();
   auto dest = ref.getValue();
   bir::StoreOp::create(builder, loc, src, dest);
 }
 
-std::unique_ptr<BIRValue> BIRGen::build_var_load(const BIRValue &refValue) {
+std::unique_ptr<BIRValue> CxxBIRGen::build_var_load(const BIRValue &refValue) {
   auto refType = dyn_cast<bir::RefType>(refValue.getValue().getType());
 
   // TODO: error or some kind
@@ -174,7 +174,7 @@ std::unique_ptr<BIRValue> BIRFunctionGuard::get_arg(size_t index) const {
 }
 
 std::unique_ptr<BIRFunctionGuard>
-BIRGen::build_fn_expr(TypeKind resultTy, rust::Slice<const TypeKind> paramTys) {
+CxxBIRGen::build_fn_expr(TypeKind resultTy, rust::Slice<const TypeKind> paramTys) {
   std::vector<mlir::Type> inputs;
   for (auto ty : paramTys) {
     inputs.push_back(mapType(ty));
@@ -212,14 +212,14 @@ std::unique_ptr<BIRValue> BIRIfGuard::get_value() const {
   return nullptr;
 }
 
-std::unique_ptr<BIRIfGuard> BIRGen::build_if_expr(const BIRValue &cond) {
+std::unique_ptr<BIRIfGuard> CxxBIRGen::build_if_expr(const BIRValue &cond) {
   auto op = bir::IfOp::create(builder, loc, mlir::TypeRange{}, cond.getValue());
   mlir::Value result = op.getNumResults() > 0 ? op.getResult() : mlir::Value();
   return std::make_unique<BIRIfGuard>(builder, &op.getThenRegion(),
                                       &op.getElseRegion(), result);
 }
 
-std::unique_ptr<BIRIfGuard> BIRGen::build_if_expr_ty(const BIRValue &cond,
+std::unique_ptr<BIRIfGuard> CxxBIRGen::build_if_expr_ty(const BIRValue &cond,
                                                      TypeKind resultTy) {
   mlir::Type ty = mapType(resultTy);
   auto op =
@@ -239,7 +239,7 @@ void BIRWhileGuard::start_body() {
   builder.setInsertionPointToEnd(&bodyRegion->front());
 }
 
-std::unique_ptr<BIRWhileGuard> BIRGen::build_while_stmt() {
+std::unique_ptr<BIRWhileGuard> CxxBIRGen::build_while_stmt() {
   auto op = bir::WhileOp::create(builder, loc);
   return std::make_unique<BIRWhileGuard>(builder, &op.getCond(), &op.getBody());
 }
@@ -249,12 +249,12 @@ void BIRScopeGuard::start_body() {
   builder.setInsertionPointToEnd(&scopeRegion->front());
 }
 
-std::unique_ptr<BIRScopeGuard> BIRGen::build_block_expr() {
+std::unique_ptr<BIRScopeGuard> CxxBIRGen::build_block_expr() {
   auto op = bir::ScopeOp::create(builder, loc, mlir::Type{});
   return std::make_unique<BIRScopeGuard>(builder, &op.getScopeRegion(), mlir::Value());
 }
 
-std::unique_ptr<BIRScopeGuard> BIRGen::build_block_expr_ty(TypeKind resultTy) {
+std::unique_ptr<BIRScopeGuard> CxxBIRGen::build_block_expr_ty(TypeKind resultTy) {
   mlir::Type ty = mapType(resultTy);
   auto op = bir::ScopeOp::create(builder, loc, ty);
   mlir::Value result = op.getNumResults() > 0 ? op.getResult(0) : mlir::Value();
@@ -267,34 +267,34 @@ std::unique_ptr<BIRValue> BIRScopeGuard::get_value() const {
   return nullptr;
 }
 
-void BIRGen::build_condition(const BIRValue &cond) {
+void CxxBIRGen::build_condition(const BIRValue &cond) {
   bir::ConditionOp::create(builder, loc, cond.getValue());
 }
 
-void BIRGen::build_continue() { bir::ContinueOp::create(builder, loc); }
+void CxxBIRGen::build_continue() { bir::ContinueOp::create(builder, loc); }
 
-void BIRGen::build_break() { bir::BreakOp::create(builder, loc); }
+void CxxBIRGen::build_break() { bir::BreakOp::create(builder, loc); }
 
-void BIRGen::build_yield(const BIRValue &val) {
+void CxxBIRGen::build_yield(const BIRValue &val) {
   bir::YieldOp::create(builder, loc, val.getValue());
 }
 
-void BIRGen::build_empty_yield() { bir::YieldOp::create(builder, loc); }
+void CxxBIRGen::build_empty_yield() { bir::YieldOp::create(builder, loc); }
 
-void BIRGen::build_print(const BIRValue &val) {
+void CxxBIRGen::build_print(const BIRValue &val) {
   bir::PrintOp::create(builder, loc, val.getValue());
 }
 
-void BIRGen::start_call(const BIRValue &callee) {
+void CxxBIRGen::start_call(const BIRValue &callee) {
   current_callee = callee.getValue();
   current_args.clear();
 }
 
-void BIRGen::add_call_arg(const BIRValue &arg) {
+void CxxBIRGen::add_call_arg(const BIRValue &arg) {
   current_args.push_back(arg.getValue());
 }
 
-std::unique_ptr<BIRValue> BIRGen::finish_call() {
+std::unique_ptr<BIRValue> CxxBIRGen::finish_call() {
   auto fnType = mlir::cast<mlir::FunctionType>(current_callee.getType());
   auto resultTypes = fnType.getResults();
 
@@ -308,13 +308,13 @@ std::unique_ptr<BIRValue> BIRGen::finish_call() {
   return std::make_unique<BIRValue>(op.getResult(0));
 }
 
-void BIRGen::build_return(const BIRValue &val) {
+void CxxBIRGen::build_return(const BIRValue &val) {
   bir::ReturnOp::create(builder, loc, val.getValue());
 }
 
-void BIRGen::build_empty_return() { bir::ReturnOp::create(builder, loc, {}); }
+void CxxBIRGen::build_empty_return() { bir::ReturnOp::create(builder, loc, {}); }
 
-void BIRGen::build_main_return() {
+void CxxBIRGen::build_main_return() {
   auto typ = bir::IntType::get(&context);
   auto val = llvm::APInt(64, 0); // return 0
   auto atr = bir::IntegerAttr::get(&context, typ, val);
@@ -322,22 +322,24 @@ void BIRGen::build_main_return() {
   bir::ReturnOp::create(builder, loc, {ret});
 }
 
-void BIRGen::dump() const { const_cast<mlir::ModuleOp &>(module).dump(); }
+void CxxBIRGen::dump() const { const_cast<mlir::ModuleOp &>(module).dump(); }
 
-rust::String BIRGen::dump_to_string() const {
+rust::String CxxBIRGen::dump_to_string() const {
   std::string s;
   llvm::raw_string_ostream os(s);
   const_cast<mlir::ModuleOp &>(module).print(os);
   return rust::String(os.str());
 }
 
-bool BIRGen::run_lowering_pipeline() {
+bool CxxBIRGen::run_lowering_pipeline() {
   mlir::PassManager pm(&context);
   bir::buildBIRLoweringPipeline(pm);
   return mlir::succeeded(pm.run(module));
 }
 
-std::unique_ptr<BIRGen> create_birgen() { return std::make_unique<BIRGen>(); }
+std::unique_ptr<CxxBIRGen> create_birgen() {
+  return std::make_unique<CxxBIRGen>();
+}
 
 } // namespace birgen
 } // namespace belalang

--- a/birgen/lib.rs
+++ b/birgen/lib.rs
@@ -46,7 +46,7 @@ mod ffi {
     }
 
     unsafe extern "C++" {
-        include!("belalang/BIRGen/BIRGen.h");
+        include!("belalang/BIRGen/CxxBIRGen.h");
 
         type BIRGuard;
         type BIRFunctionGuard;
@@ -54,69 +54,74 @@ mod ffi {
         type BIRWhileGuard;
         type BIRScopeGuard;
         type BIRValue;
-        type BIRGen;
+        type CxxBIRGen;
 
-        fn create_birgen() -> UniquePtr<BIRGen>;
+        fn create_birgen() -> UniquePtr<CxxBIRGen>;
 
-        fn build_constant_int(self: Pin<&mut BIRGen>, val: i64) -> UniquePtr<BIRValue>;
-        fn build_constant_float(self: Pin<&mut BIRGen>, val: f64) -> UniquePtr<BIRValue>;
-        fn build_constant_string(self: Pin<&mut BIRGen>, val: &str) -> UniquePtr<BIRValue>;
-        fn build_constant_bool(self: Pin<&mut BIRGen>, val: bool) -> UniquePtr<BIRValue>;
-        fn build_binop(self: Pin<&mut BIRGen>, kind: BinOpKind, lhs: &BIRValue, rhs: &BIRValue) -> UniquePtr<BIRValue>;
-        fn build_print(self: Pin<&mut BIRGen>, val: &BIRValue);
-        fn build_var_declare(self: Pin<&mut BIRGen>, v: &BIRValue, name: &str) -> UniquePtr<BIRValue>;
-        fn build_var_declare_ty(self: Pin<&mut BIRGen>, v: TypeKind, name: &str) -> UniquePtr<BIRValue>;
-        fn build_var_load(self: Pin<&mut BIRGen>, refValue: &BIRValue) -> UniquePtr<BIRValue>;
-        fn build_var_store(self: Pin<&mut BIRGen>, v: &BIRValue, refv: &BIRValue);
+        fn build_constant_int(self: Pin<&mut CxxBIRGen>, val: i64) -> UniquePtr<BIRValue>;
+        fn build_constant_float(self: Pin<&mut CxxBIRGen>, val: f64) -> UniquePtr<BIRValue>;
+        fn build_constant_string(self: Pin<&mut CxxBIRGen>, val: &str) -> UniquePtr<BIRValue>;
+        fn build_constant_bool(self: Pin<&mut CxxBIRGen>, val: bool) -> UniquePtr<BIRValue>;
+        fn build_binop(
+            self: Pin<&mut CxxBIRGen>,
+            kind: BinOpKind,
+            lhs: &BIRValue,
+            rhs: &BIRValue,
+        ) -> UniquePtr<BIRValue>;
+        fn build_print(self: Pin<&mut CxxBIRGen>, val: &BIRValue);
+        fn build_var_declare(self: Pin<&mut CxxBIRGen>, v: &BIRValue, name: &str) -> UniquePtr<BIRValue>;
+        fn build_var_declare_ty(self: Pin<&mut CxxBIRGen>, v: TypeKind, name: &str) -> UniquePtr<BIRValue>;
+        fn build_var_load(self: Pin<&mut CxxBIRGen>, refValue: &BIRValue) -> UniquePtr<BIRValue>;
+        fn build_var_store(self: Pin<&mut CxxBIRGen>, v: &BIRValue, refv: &BIRValue);
         fn build_fn_expr(
-            self: Pin<&mut BIRGen>,
+            self: Pin<&mut CxxBIRGen>,
             resultTy: TypeKind,
             paramTys: &[TypeKind],
         ) -> UniquePtr<BIRFunctionGuard>;
-        fn build_return(self: Pin<&mut BIRGen>, val: &BIRValue);
-        fn build_empty_return(self: Pin<&mut BIRGen>);
-        fn build_main_return(self: Pin<&mut BIRGen>);
-        fn build_if_expr(self: Pin<&mut BIRGen>, cond: &BIRValue) -> UniquePtr<BIRIfGuard>;
-        fn build_if_expr_ty(self: Pin<&mut BIRGen>, cond: &BIRValue, resultTy: TypeKind) -> UniquePtr<BIRIfGuard>;
-        fn build_while_stmt(self: Pin<&mut BIRGen>) -> UniquePtr<BIRWhileGuard>;
-        fn build_block_expr(self: Pin<&mut BIRGen>) -> UniquePtr<BIRScopeGuard>;
-        fn build_block_expr_ty(self: Pin<&mut BIRGen>, resultTy: TypeKind) -> UniquePtr<BIRScopeGuard>;
-        fn build_condition(self: Pin<&mut BIRGen>, cond: &BIRValue);
-        fn build_continue(self: Pin<&mut BIRGen>);
-        fn build_break(self: Pin<&mut BIRGen>);
+        fn build_return(self: Pin<&mut CxxBIRGen>, val: &BIRValue);
+        fn build_empty_return(self: Pin<&mut CxxBIRGen>);
+        fn build_main_return(self: Pin<&mut CxxBIRGen>);
+        fn build_if_expr(self: Pin<&mut CxxBIRGen>, cond: &BIRValue) -> UniquePtr<BIRIfGuard>;
+        fn build_if_expr_ty(self: Pin<&mut CxxBIRGen>, cond: &BIRValue, resultTy: TypeKind) -> UniquePtr<BIRIfGuard>;
+        fn build_while_stmt(self: Pin<&mut CxxBIRGen>) -> UniquePtr<BIRWhileGuard>;
+        fn build_block_expr(self: Pin<&mut CxxBIRGen>) -> UniquePtr<BIRScopeGuard>;
+        fn build_block_expr_ty(self: Pin<&mut CxxBIRGen>, resultTy: TypeKind) -> UniquePtr<BIRScopeGuard>;
+        fn build_condition(self: Pin<&mut CxxBIRGen>, cond: &BIRValue);
+        fn build_continue(self: Pin<&mut CxxBIRGen>);
+        fn build_break(self: Pin<&mut CxxBIRGen>);
         fn start_cond(self: Pin<&mut BIRWhileGuard>);
         fn start_body(self: Pin<&mut BIRWhileGuard>);
-        fn build_yield(self: Pin<&mut BIRGen>, val: &BIRValue);
-        fn build_empty_yield(self: Pin<&mut BIRGen>);
+        fn build_yield(self: Pin<&mut CxxBIRGen>, val: &BIRValue);
+        fn build_empty_yield(self: Pin<&mut CxxBIRGen>);
         fn start_then(self: Pin<&mut BIRIfGuard>);
         fn start_else(self: Pin<&mut BIRIfGuard>);
         fn start_body(self: Pin<&mut BIRScopeGuard>);
         fn get_value(self: &BIRIfGuard) -> UniquePtr<BIRValue>;
         fn get_value(self: &BIRScopeGuard) -> UniquePtr<BIRValue>;
-        fn run_lowering_pipeline(self: Pin<&mut BIRGen>) -> bool;
-        fn dump(self: &BIRGen);
-        fn dump_to_string(self: &BIRGen) -> String;
-        fn get_module_ptr(self: &BIRGen) -> usize;
+        fn run_lowering_pipeline(self: Pin<&mut CxxBIRGen>) -> bool;
+        fn dump(self: &CxxBIRGen);
+        fn dump_to_string(self: &CxxBIRGen) -> String;
+        fn get_module_ptr(self: &CxxBIRGen) -> usize;
 
         // <AutoGenerated>
 
         // BreakOp
-        fn build_break_op(self: Pin<&mut BIRGen>);
+        fn build_break_op(self: Pin<&mut CxxBIRGen>);
 
         // ContinueOp
-        fn build_continue_op(self: Pin<&mut BIRGen>);
+        fn build_continue_op(self: Pin<&mut CxxBIRGen>);
 
         // WhileOp
         type BIRWhileOpGuard;
         fn enter_cond(self: Pin<&mut BIRWhileOpGuard>);
         fn enter_body(self: Pin<&mut BIRWhileOpGuard>);
-        fn build_while_op(self: Pin<&mut BIRGen>) -> UniquePtr<BIRWhileOpGuard>;
+        fn build_while_op(self: Pin<&mut CxxBIRGen>) -> UniquePtr<BIRWhileOpGuard>;
 
         // </AutoGenerated>
 
-        fn start_call(self: Pin<&mut BIRGen>, callee: &BIRValue);
-        fn add_call_arg(self: Pin<&mut BIRGen>, arg: &BIRValue);
-        fn finish_call(self: Pin<&mut BIRGen>) -> UniquePtr<BIRValue>;
+        fn start_call(self: Pin<&mut CxxBIRGen>, callee: &BIRValue);
+        fn add_call_arg(self: Pin<&mut CxxBIRGen>, arg: &BIRValue);
+        fn finish_call(self: Pin<&mut CxxBIRGen>) -> UniquePtr<BIRValue>;
 
         fn get_value(self: &BIRFunctionGuard) -> UniquePtr<BIRValue>;
         fn get_arg(self: &BIRFunctionGuard, index: usize) -> UniquePtr<BIRValue>;
@@ -126,7 +131,7 @@ mod ffi {
 pub struct BIRGen<'sess> {
     #[allow(dead_code)]
     session: &'sess Session,
-    inner: cxx::UniquePtr<ffi::BIRGen>,
+    inner: cxx::UniquePtr<ffi::CxxBIRGen>,
     symbol_table: HashMap<Symbol, cxx::UniquePtr<ffi::BIRValue>>,
     ty_checker: ty::TypeChecker<'sess>,
 }

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -187,6 +187,7 @@ cc_library(
     includes = ["."],
     deps = [
         ":BelalangCXXBindingsIncGen",
+        ":Diag",
     ],
 )
 

--- a/include/belalang/AST/ASTVisitor.h
+++ b/include/belalang/AST/ASTVisitor.h
@@ -3,22 +3,27 @@
 
 #include "belalang/AST/Decl.h"
 #include "belalang/AST/Expr.h"
-#include "belalang/AST/Stmt.h"
 #include "belalang/AST/Program.h"
+#include "belalang/AST/Stmt.h"
 
 namespace belalang {
 namespace ast {
 
-template <typename Derived> class ASTVisitor {
+template <typename Derived, typename RetT = void> class ASTVisitor {
 public:
   void visitProgram(Program *prog) {
     for (Stmt *stmt : prog->getStmts())
       visitStmt(stmt);
   }
 
-  void visitStmt(Stmt *stmt) {
-    if (!stmt)
-      return;
+  RetT visitStmt(Stmt *stmt) {
+    if (!stmt) {
+      if constexpr (std::is_same_v<RetT, void>) {
+        return;
+      } else {
+        return RetT{};
+      }
+    }
 
     switch (stmt->getKind()) {
       // clang-format off
@@ -31,9 +36,14 @@ public:
     }
   }
 
-  void visitExpr(Expr *expr) {
-    if (!expr)
-      return;
+  RetT visitExpr(Expr *expr) {
+    if (!expr) {
+      if constexpr (std::is_same_v<RetT, void>) {
+        return;
+      } else {
+        return RetT{};
+      }
+    }
 
     switch (expr->getKind()) {
       // clang-format off
@@ -46,9 +56,14 @@ public:
     }
   }
 
-  void visitDecl(Decl *decl) {
-    if (!decl)
-      return;
+  RetT visitDecl(Decl *decl) {
+    if (!decl) {
+      if constexpr (std::is_same_v<RetT, void>) {
+        return;
+      } else {
+        return RetT{};
+      }
+    }
 
     switch (decl->getKind()) {
       // clang-format off
@@ -62,11 +77,11 @@ public:
   }
 
 #define STMT(name)                                                             \
-  void visit##name##Stmt(name##Stmt *) { return; }
+  RetT visit##name##Stmt(name##Stmt *) { return; }
 #define EXPR(name)                                                             \
-  void visit##name##Expr(name##Expr *) { return; }
+  RetT visit##name##Expr(name##Expr *) { return; }
 #define DECL(name)                                                             \
-  void visit##name##Decl(name##Decl *) { return; }
+  RetT visit##name##Decl(name##Decl *) { return; }
 #include "ASTNodes.def"
 };
 

--- a/include/belalang/AST/ASTVisitor.h
+++ b/include/belalang/AST/ASTVisitor.h
@@ -77,11 +77,23 @@ public:
   }
 
 #define STMT(name)                                                             \
-  RetT visit##name##Stmt(name##Stmt *) { return; }
+  RetT visit##name##Stmt(name##Stmt *) {                                       \
+    if constexpr (!std::is_same_v<RetT, void>) {                               \
+      return RetT{};                                                           \
+    }                                                                          \
+  }
 #define EXPR(name)                                                             \
-  RetT visit##name##Expr(name##Expr *) { return; }
+  RetT visit##name##Expr(name##Expr *) {                                       \
+    if constexpr (!std::is_same_v<RetT, void>) {                               \
+      return RetT{};                                                           \
+    }                                                                          \
+  }
 #define DECL(name)                                                             \
-  RetT visit##name##Decl(name##Decl *) { return; }
+  RetT visit##name##Decl(name##Decl *) {                                       \
+    if constexpr (!std::is_same_v<RetT, void>) {                               \
+      return RetT{};                                                           \
+    }                                                                          \
+  }
 #include "ASTNodes.def"
 };
 

--- a/include/belalang/BIRGen/BIRGen.h
+++ b/include/belalang/BIRGen/BIRGen.h
@@ -1,0 +1,47 @@
+#ifndef BELALANG_BIRGEN_BIRGEN_H_
+#define BELALANG_BIRGEN_BIRGEN_H_
+
+#include "belalang/AST/ASTVisitor.h"
+#include "belalang/BIRGen/TypeChecker.h"
+#include "belalang/Diag/Diag.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include <string>
+
+namespace belalang {
+namespace birgen {
+
+class BIRGen : public ast::ASTVisitor<BIRGen, mlir::Value> {
+public:
+  BIRGen(diag::DiagnosticEngine &diagEngine);
+  ~BIRGen() = default;
+
+  mlir::ModuleOp generateProgram(ast::Program *prog);
+  bool runLoweringPipeline();
+  std::string dumpToString() const;
+
+#define STMT(name) mlir::Value visit##name##Stmt(ast::name##Stmt *);
+#define EXPR(name) mlir::Value visit##name##Expr(ast::name##Expr *);
+#define DECL(name) mlir::Value visit##name##Decl(ast::name##Decl *);
+#include "belalang/AST/ASTNodes.def"
+
+private:
+  diag::DiagnosticEngine &diagEngine;
+  TypeChecker typeChecker;
+  llvm::StringMap<mlir::Value> symbolTable;
+
+  void buildMainReturn();
+  mlir::Type mapTypeName(llvm::StringRef name);
+
+  mlir::MLIRContext context;
+  mlir::ModuleOp module;
+  mlir::OpBuilder builder;
+  mlir::Location loc;
+};
+
+} // namespace birgen
+} // namespace belalang
+
+#endif // BELALANG_BIRGEN_BIRGEN_H_

--- a/include/belalang/BIRGen/CxxBIRGen.h
+++ b/include/belalang/BIRGen/CxxBIRGen.h
@@ -1,5 +1,5 @@
-#ifndef BELALANG_BIRGEN_BIRGEN_H_
-#define BELALANG_BIRGEN_BIRGEN_H_
+#ifndef BELALANG_BIRGEN_CXXBIRGEN_H_
+#define BELALANG_BIRGEN_CXXBIRGEN_H_
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -17,7 +17,7 @@ class BIRFunctionGuard;
 class BIRIfGuard;
 class BIRWhileGuard;
 class BIRScopeGuard;
-class BIRGen;
+class CxxBIRGen;
 
 // NOTE: manual forward decl
 class BIRWhileOpGuard;
@@ -124,15 +124,15 @@ private:
 };
 
 // -----------------------------------------------------------------------------
-// BIRGen
+// CxxBIRGen
 // -----------------------------------------------------------------------------
 
-std::unique_ptr<BIRGen> create_birgen();
+std::unique_ptr<CxxBIRGen> create_birgen();
 
-class BIRGen {
+class CxxBIRGen {
 public:
-  BIRGen();
-  ~BIRGen() = default;
+  CxxBIRGen();
+  ~CxxBIRGen() = default;
 
   std::unique_ptr<BIRValue> build_constant_int(int64_t val);
   std::unique_ptr<BIRValue> build_constant_float(double val);
@@ -193,4 +193,4 @@ private:
 } // namespace birgen 
 } // namespace belalang
 
-#endif // BELALANG_BIRGEN_BIRGEN_H_
+#endif // BELALANG_BIRGEN_CXXBIRGEN_H_

--- a/include/belalang/BIRGen/TypeChecker.h
+++ b/include/belalang/BIRGen/TypeChecker.h
@@ -1,0 +1,51 @@
+#ifndef BELALANG_BIRGEN_TYPECHECKER_H_
+#define BELALANG_BIRGEN_TYPECHECKER_H_
+
+#include "belalang/AST/ASTVisitor.h"
+#include "belalang/Diag/Diag.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include <string>
+
+namespace belalang {
+namespace birgen {
+
+enum class Type {
+  String,
+  Integer,
+  Float,
+  Boolean,
+  None,
+};
+
+class TypeChecker : public ast::ASTVisitor<TypeChecker, Type> {
+public:
+  TypeChecker(diag::DiagnosticEngine &diagEngine);
+
+  void infer(ast::Program *prog);
+  void checkExpr(ast::Expr *expr, Type expected);
+
+  Type visitIntLitExpr(ast::IntLitExpr *expr);
+  Type visitFloatLitExpr(ast::FloatLitExpr *expr);
+  Type visitStringLitExpr(ast::StringLitExpr *expr);
+  Type visitBoolExpr(ast::BoolExpr *expr);
+  Type visitIdentifierExpr(ast::IdentifierExpr *expr);
+  Type visitInfixExpr(ast::InfixExpr *expr);
+  Type visitBlockExpr(ast::BlockExpr *expr);
+  Type visitIfExpr(ast::IfExpr *expr);
+  Type visitVarDecl(ast::VarDecl *decl);
+  Type visitDeclStmt(ast::DeclStmt *stmt);
+  Type visitExprStmt(ast::ExprStmt *stmt);
+
+private:
+  diag::DiagnosticEngine &diagEngine;
+  llvm::StringMap<Type> env;
+
+  std::string tyToStr(Type ty) const;
+  Type strToTy(llvm::StringRef str) const;
+};
+
+} // namespace birgen
+} // namespace belalang
+
+#endif // BELALANG_BIRGEN_TYPECHECKER_H_

--- a/lib/BIRGen/BIRGen.cpp
+++ b/lib/BIRGen/BIRGen.cpp
@@ -1,0 +1,519 @@
+#include "belalang/BIRGen/BIRGen.h"
+
+#include "belalang/AST/Decl.h"
+#include "belalang/AST/Expr.h"
+#include "belalang/AST/Stmt.h"
+#include "belalang/BIR/IR/BIR.h"
+#include "belalang/BIR/Passes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/PassManager.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace belalang {
+namespace birgen {
+
+using namespace ast;
+using namespace lexer;
+
+BIRGen::BIRGen(diag::DiagnosticEngine &diagEngine)
+    : diagEngine(diagEngine), typeChecker(diagEngine), builder(&context),
+      loc(builder.getUnknownLoc()) {
+  // Load dialects.
+  mlir::DialectRegistry registry;
+  registry.insert<bir::BIRDialect, mlir::LLVM::LLVMDialect>();
+  context.appendDialectRegistry(registry);
+  context.getOrLoadDialect<bir::BIRDialect>();
+
+  // Create the module.
+  module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  // Create the main function.
+  auto retTy = bir::IntType::get(&context);
+  auto main = bir::FuncOp::create(
+      builder, loc, "main", mlir::FunctionType::get(&context, {}, {retTy}));
+  mlir::Block *entry = main.addEntryBlock();
+  builder.setInsertionPointToStart(entry);
+}
+
+mlir::ModuleOp BIRGen::generateProgram(Program *prog) {
+  visitProgram(prog);
+  buildMainReturn();
+  return module;
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+mlir::Type BIRGen::mapTypeName(llvm::StringRef name) {
+  if (name == "String")
+    return bir::StringType::get(&context);
+  if (name == "Int")
+    return bir::IntType::get(&context);
+  if (name == "Float")
+    return bir::FloatType::get(&context);
+  if (name == "Bool")
+    return bir::BoolType::get(&context);
+
+  llvm_unreachable("unknown type");
+}
+
+static mlir::Type mapType(mlir::MLIRContext *context, Type ty) {
+  switch (ty) {
+  case Type::Integer:
+    return bir::IntType::get(context);
+  case Type::Boolean:
+    return bir::BoolType::get(context);
+  case Type::String:
+    return bir::StringType::get(context);
+  case Type::Float:
+    return bir::FloatType::get(context);
+  default:
+    return nullptr;
+  }
+}
+
+namespace {
+
+template <typename Op>
+mlir::Value buildBinop(mlir::OpBuilder &builder, mlir::Location loc,
+                       mlir::Value lhs, mlir::Value rhs) {
+  auto type = lhs.getType();
+  auto op = Op::create(builder, loc, type, lhs, rhs);
+  return op.getResult();
+}
+
+mlir::Value buildBinopCmp(mlir::OpBuilder &builder, mlir::Location loc,
+                          bir::CmpOpKind kind, mlir::Value lhs,
+                          mlir::Value rhs) {
+  auto op = bir::CmpOp::create(builder, loc, kind, lhs, rhs);
+  return op.getResult();
+}
+
+mlir::Value buildBinopArith(mlir::OpBuilder &builder, mlir::Location loc,
+                            TokenKind op, mlir::Value lhs, mlir::Value rhs) {
+  switch (op) {
+  case TokenKind::Add:
+    return buildBinop<bir::AddOp>(builder, loc, lhs, rhs);
+  case TokenKind::Sub:
+    return buildBinop<bir::SubOp>(builder, loc, lhs, rhs);
+  case TokenKind::Mul:
+    return buildBinop<bir::MulOp>(builder, loc, lhs, rhs);
+  case TokenKind::Div:
+    return buildBinop<bir::DivOp>(builder, loc, lhs, rhs);
+  case TokenKind::Mod:
+    return buildBinop<bir::ModOp>(builder, loc, lhs, rhs);
+  case TokenKind::Lt:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::lt, lhs, rhs);
+  case TokenKind::Le:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::le, lhs, rhs);
+  case TokenKind::Gt:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::gt, lhs, rhs);
+  case TokenKind::Ge:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::ge, lhs, rhs);
+  case TokenKind::Eq:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::eq, lhs, rhs);
+  case TokenKind::Ne:
+    return buildBinopCmp(builder, loc, bir::CmpOpKind::ne, lhs, rhs);
+  default:
+    llvm_unreachable("unsupported infix operator");
+  }
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Statements
+// -----------------------------------------------------------------------------
+
+mlir::Value BIRGen::visitReturnStmt(ReturnStmt *stmt) {
+  if (Expr *returnValue = stmt->getReturnValue()) {
+    mlir::Value val = visitExpr(returnValue);
+    bir::ReturnOp::create(builder, loc, val);
+  } else {
+    bir::ReturnOp::create(builder, loc, {});
+  }
+  return {};
+}
+
+mlir::Value BIRGen::visitWhileStmt(WhileStmt *stmt) {
+  auto whileOp = bir::WhileOp::create(builder, loc);
+
+  builder.createBlock(&whileOp.getCond());
+  mlir::Value cond = visitExpr(stmt->getCond());
+  bir::ConditionOp::create(builder, loc, cond);
+
+  builder.createBlock(&whileOp.getBody());
+
+  auto scopeOp =
+      bir::ScopeOp::create(builder, loc, llvm::SmallVector<mlir::Type, 0>{});
+  builder.createBlock(&scopeOp.getScopeRegion());
+
+  for (Stmt *s : stmt->getBody()->getStmts()) {
+    visitStmt(s);
+  }
+
+  bir::YieldOp::create(builder, loc);
+
+  builder.setInsertionPointAfter(scopeOp);
+  bir::YieldOp::create(builder, loc);
+
+  builder.setInsertionPointAfter(whileOp);
+  return {};
+}
+
+mlir::Value BIRGen::visitBreakStmt(BreakStmt *stmt) {
+  bir::BreakOp::create(builder, loc);
+  return {};
+}
+
+mlir::Value BIRGen::visitContinueStmt(ContinueStmt *stmt) {
+  bir::ContinueOp::create(builder, loc);
+  return {};
+}
+
+mlir::Value BIRGen::visitImportStmt(ImportStmt *stmt) {
+  llvm_unreachable("not yet implemented");
+}
+
+mlir::Value BIRGen::visitExprStmt(ExprStmt *stmt) {
+  visitExpr(stmt->getExpr());
+  return {};
+}
+
+mlir::Value BIRGen::visitDeclStmt(DeclStmt *stmt) {
+  visitDecl(stmt->getDecl());
+  return {};
+}
+
+// -----------------------------------------------------------------------------
+// Expressions
+// -----------------------------------------------------------------------------
+
+mlir::Value BIRGen::visitIntLitExpr(IntLitExpr *expr) {
+  auto type = builder.getType<bir::IntType>();
+  llvm::APInt value(64, expr->getValue());
+  auto attr = bir::IntegerAttr::get(&context, type, value);
+  return bir::ConstantOp::create(builder, loc, type, attr).getResult();
+}
+
+mlir::Value BIRGen::visitFloatLitExpr(FloatLitExpr *expr) {
+  auto type = builder.getType<bir::FloatType>();
+  llvm::APFloat value(expr->getValue());
+  auto attr = bir::FloatAttr::get(&context, type, value);
+  return bir::ConstantOp::create(builder, loc, type, attr).getResult();
+}
+
+mlir::Value BIRGen::visitStringLitExpr(StringLitExpr *expr) {
+  auto type = builder.getType<bir::StringType>();
+  auto attr = bir::StringAttr::get(&context, type, expr->getValue());
+  return bir::ConstantOp::create(builder, loc, type, attr).getResult();
+}
+
+mlir::Value BIRGen::visitBoolExpr(BoolExpr *expr) {
+  auto type = builder.getType<bir::BoolType>();
+  auto attr = bir::BoolAttr::get(&context, type, expr->getValue());
+  return bir::ConstantOp::create(builder, loc, type, attr).getResult();
+}
+
+mlir::Value BIRGen::visitArrayLitExpr(ArrayLitExpr *expr) {
+  llvm_unreachable("not yet implemented");
+}
+
+mlir::Value BIRGen::visitVarExpr(VarExpr *expr) {
+  auto it = symbolTable.find(expr->getName());
+  if (it == symbolTable.end()) {
+    llvm_unreachable("variable not found");
+  }
+
+  mlir::Value dest = it->second;
+  mlir::Value rhs = visitExpr(expr->getValue());
+
+  if (expr->getAssignOp() == TokenKind::Assign) {
+    bir::StoreOp::create(builder, loc, rhs, dest);
+    return rhs;
+  }
+
+  auto refType = llvm::cast<bir::RefType>(dest.getType());
+  auto loadOp =
+      bir::VarLoadOp::create(builder, loc, refType.getReferent(), dest);
+  mlir::Value lhs = loadOp.getResult();
+
+  mlir::Value res;
+  switch (expr->getAssignOp()) {
+  case TokenKind::AddAssign:
+    res = bir::AddOp::create(builder, loc, lhs.getType(), lhs, rhs);
+    break;
+  case TokenKind::SubAssign:
+    res = bir::SubOp::create(builder, loc, lhs.getType(), lhs, rhs);
+    break;
+  case TokenKind::MulAssign:
+    res = bir::MulOp::create(builder, loc, lhs.getType(), lhs, rhs);
+    break;
+  case TokenKind::DivAssign:
+    res = bir::DivOp::create(builder, loc, lhs.getType(), lhs, rhs);
+    break;
+  default:
+    llvm_unreachable("unknown assign op");
+  }
+
+  bir::StoreOp::create(builder, loc, res, dest);
+  return res;
+}
+
+mlir::Value BIRGen::visitFunctionLitExpr(FunctionLitExpr *expr) {
+  if (expr->getExplicitType().empty())
+    llvm_unreachable("not yet implemented");
+
+  mlir::Type ty = mapTypeName(expr->getExplicitType());
+  llvm::SmallVector<mlir::Type, 0> paramsTy;
+
+  for (VarDecl *param : expr->getParams()) {
+    paramsTy.push_back(mapTypeName(param->getExplicitType()));
+  }
+
+  auto fnTy = mlir::FunctionType::get(&context, paramsTy, {ty});
+  auto op = bir::FuncExprOp::create(builder, loc, fnTy);
+
+  {
+    mlir::OpBuilder::InsertionGuard g(builder);
+    llvm::SmallVector<mlir::Location> locs(paramsTy.size(), loc);
+    builder.createBlock(&op.getBody(), {}, paramsTy, locs);
+
+    auto args = op.getBody().front().getArguments();
+    for (size_t i = 0; i < args.size(); ++i) {
+      VarDecl *paramDecl = expr->getParams()[i];
+      mlir::Type paramType = args[i].getType();
+      auto refType = bir::RefType::get(&context, paramType);
+      auto dest =
+          bir::DeclareOp::create(builder, loc, refType, paramDecl->getName());
+      bir::StoreOp::create(builder, loc, args[i], dest);
+      symbolTable[paramDecl->getName()] = dest;
+    }
+
+    for (Stmt *stmt : expr->getBody()->getStmts()) {
+      visitStmt(stmt);
+    }
+  }
+
+  return op.getResult();
+}
+
+mlir::Value BIRGen::visitCallExpr(CallExpr *expr) {
+  if (auto *ident = llvm::dyn_cast<IdentifierExpr>(expr->getCallee())) {
+    if (ident->getName() == "print") {
+      mlir::Value value = visitExpr(expr->getArgs()[0]);
+      bir::PrintOp::create(builder, loc, value);
+      return {};
+    }
+  }
+
+  mlir::Value callee = visitExpr(expr->getCallee());
+  llvm::SmallVector<mlir::Value, 4> operands;
+  for (Expr *arg : expr->getArgs()) {
+    operands.push_back(visitExpr(arg));
+  }
+
+  auto fnType = llvm::cast<mlir::FunctionType>(callee.getType());
+  auto resultTypes = fnType.getResults();
+
+  auto callOp = bir::CallIndirectOp::create(builder, loc, resultTypes, callee,
+                                            operands, nullptr, nullptr);
+
+  if (resultTypes.empty())
+    return {};
+  return callOp.getResult(0);
+}
+
+mlir::Value BIRGen::visitIndexExpr(IndexExpr *expr) {
+  llvm_unreachable("not yet implemented");
+}
+
+mlir::Value BIRGen::visitIdentifierExpr(IdentifierExpr *expr) {
+  auto it = symbolTable.find(expr->getName());
+  if (it == symbolTable.end()) {
+    llvm_unreachable("unknown identifier");
+  }
+
+  mlir::Value ref = it->second;
+  auto refType = llvm::cast<bir::RefType>(ref.getType());
+  auto loadOp =
+      bir::VarLoadOp::create(builder, loc, refType.getReferent(), ref);
+  return loadOp.getResult();
+}
+
+mlir::Value BIRGen::visitIfExpr(IfExpr *expr) {
+  mlir::Value cond = visitExpr(expr->getCond());
+
+  Type inferredTy = typeChecker.visitIfExpr(expr);
+  llvm::SmallVector<mlir::Type, 1> resultTypes;
+  if (inferredTy != Type::None) {
+    if (auto ty = mapType(&context, inferredTy)) {
+      resultTypes.push_back(ty);
+    }
+  }
+
+  auto ifOp = bir::IfOp::create(builder, loc, resultTypes, cond);
+
+  builder.createBlock(&ifOp.getThenRegion());
+  mlir::Value thenVal = nullptr;
+  for (Stmt *stmt : expr->getThen()->getStmts()) {
+    if (auto *exprStmt = llvm::dyn_cast<ExprStmt>(stmt)) {
+      thenVal = visitExpr(exprStmt->getExpr());
+    } else {
+      visitStmt(stmt);
+      thenVal = nullptr;
+    }
+  }
+  if (thenVal && !resultTypes.empty()) {
+    bir::YieldOp::create(builder, loc, thenVal);
+  } else {
+    bir::YieldOp::create(builder, loc);
+  }
+
+  if (Expr *altExpr = expr->getAlt()) {
+    builder.createBlock(&ifOp.getElseRegion());
+    mlir::Value elseVal = nullptr;
+    if (auto *altBlock = llvm::dyn_cast<BlockExpr>(altExpr)) {
+      for (Stmt *stmt : altBlock->getStmts()) {
+        if (auto *exprStmt = llvm::dyn_cast<ExprStmt>(stmt)) {
+          elseVal = visitExpr(exprStmt->getExpr());
+        } else {
+          visitStmt(stmt);
+          elseVal = nullptr;
+        }
+      }
+    } else {
+      elseVal = visitExpr(altExpr);
+    }
+    if (elseVal && !resultTypes.empty()) {
+      bir::YieldOp::create(builder, loc, elseVal);
+    } else {
+      bir::YieldOp::create(builder, loc);
+    }
+  } else {
+    builder.createBlock(&ifOp.getElseRegion());
+    bir::YieldOp::create(builder, loc);
+  }
+
+  builder.setInsertionPointAfter(ifOp);
+  if (resultTypes.empty())
+    return {};
+  return ifOp.getResult();
+}
+
+mlir::Value BIRGen::visitInfixExpr(InfixExpr *expr) {
+  mlir::Value lhs = visitExpr(expr->getLeft());
+  mlir::Value rhs = visitExpr(expr->getRight());
+  return buildBinopArith(builder, loc, expr->getInfixOp(), lhs, rhs);
+}
+
+mlir::Value BIRGen::visitPrefixExpr(PrefixExpr *expr) {
+  llvm_unreachable("not yet implemented");
+}
+
+mlir::Value BIRGen::visitBlockExpr(BlockExpr *expr) {
+  Type inferredTy = typeChecker.visitBlockExpr(expr);
+  llvm::SmallVector<mlir::Type, 1> resultTypes;
+  if (inferredTy != Type::None) {
+    if (auto ty = mapType(&context, inferredTy)) {
+      resultTypes.push_back(ty);
+    }
+  }
+
+  auto scopeOp = bir::ScopeOp::create(builder, loc, resultTypes);
+  builder.createBlock(&scopeOp.getScopeRegion());
+
+  mlir::Value lastVal;
+  for (Stmt *stmt : expr->getStmts()) {
+    if (auto *exprStmt = llvm::dyn_cast<ExprStmt>(stmt)) {
+      lastVal = visitExpr(exprStmt->getExpr());
+    } else {
+      visitStmt(stmt);
+      lastVal = nullptr;
+    }
+  }
+
+  if (lastVal && !resultTypes.empty()) {
+    bir::YieldOp::create(builder, loc, lastVal);
+  } else {
+    bir::YieldOp::create(builder, loc);
+  }
+
+  builder.setInsertionPointAfter(scopeOp);
+  if (resultTypes.empty())
+    return {};
+  return scopeOp.getResult(0);
+}
+
+mlir::Value BIRGen::visitMemberAccessExpr(MemberAccessExpr *expr) {
+  llvm_unreachable("not yet implemented");
+}
+
+mlir::Value BIRGen::visitStructLiteralExpr(StructLiteralExpr *expr) {
+  llvm_unreachable("not yet implemented");
+}
+
+// -----------------------------------------------------------------------------
+// Declarations
+// -----------------------------------------------------------------------------
+
+mlir::Value BIRGen::visitVarDecl(VarDecl *decl) {
+  Expr *value = decl->getValue();
+  typeChecker.visitVarDecl(decl);
+
+  mlir::Type type;
+  mlir::Value src;
+  if (value) {
+    src = visitExpr(value);
+    type = src.getType();
+  } else {
+    type = mapTypeName(decl->getExplicitType());
+  }
+
+  auto refType = bir::RefType::get(&context, type);
+  auto dest = bir::DeclareOp::create(builder, loc, refType, decl->getName());
+  if (src) {
+    bir::StoreOp::create(builder, loc, src, dest);
+  }
+  symbolTable[decl->getName()] = dest;
+  return dest;
+}
+
+mlir::Value BIRGen::visitStructDecl(StructDecl *decl) {
+  llvm_unreachable("not yet implemented");
+}
+
+// -----------------------------------------------------------------------------
+// Module
+// -----------------------------------------------------------------------------
+
+void BIRGen::buildMainReturn() {
+  auto typ = bir::IntType::get(&context);
+  auto val = llvm::APInt(64, 0); // return 0
+  auto atr = bir::IntegerAttr::get(&context, typ, val);
+  auto ret = bir::ConstantOp::create(builder, loc, typ, atr);
+  bir::ReturnOp::create(builder, loc, {ret});
+}
+
+bool BIRGen::runLoweringPipeline() {
+  mlir::PassManager pm(&context);
+  bir::buildBIRLoweringPipeline(pm);
+  return mlir::succeeded(pm.run(module));
+}
+
+std::string BIRGen::dumpToString() const {
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  const_cast<mlir::ModuleOp &>(module).print(os);
+  return os.str();
+}
+
+} // namespace birgen
+} // namespace belalang

--- a/lib/BIRGen/TypeChecker.cpp
+++ b/lib/BIRGen/TypeChecker.cpp
@@ -1,0 +1,180 @@
+#include "belalang/BIRGen/TypeChecker.h"
+
+#include "belalang/AST/Decl.h"
+#include "belalang/AST/Expr.h"
+#include "belalang/AST/Stmt.h"
+#include "belalang/Diag/Diag.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <optional>
+
+namespace belalang {
+namespace birgen {
+
+TypeChecker::TypeChecker(diag::DiagnosticEngine &diagEngine)
+    : diagEngine(diagEngine) {}
+
+void TypeChecker::infer(ast::Program *prog) { visitProgram(prog); }
+
+void TypeChecker::checkExpr(ast::Expr *expr, Type expected) {
+  Type inferred = visitExpr(expr);
+  if (inferred != expected) {
+    auto label = diag::Label::primary(
+        expr->getSpanStart(), expr->getSpanEnd(),
+        llvm::formatv("expected type `{0}`, found type `{1}`",
+                      tyToStr(expected), tyToStr(inferred)));
+    diagEngine.print(
+        diag::Diagnostic::error("mismatched type").withLabel(label));
+  }
+}
+
+Type TypeChecker::visitIntLitExpr(ast::IntLitExpr *expr) {
+  return Type::Integer;
+}
+
+Type TypeChecker::visitFloatLitExpr(ast::FloatLitExpr *expr) {
+  return Type::Float;
+}
+
+Type TypeChecker::visitStringLitExpr(ast::StringLitExpr *expr) {
+  return Type::String;
+}
+
+Type TypeChecker::visitBoolExpr(ast::BoolExpr *expr) { return Type::Boolean; }
+
+Type TypeChecker::visitIdentifierExpr(ast::IdentifierExpr *expr) {
+  auto it = env.find(expr->getName());
+  if (it != env.end()) {
+    return it->second;
+  }
+  return Type::None;
+}
+
+Type TypeChecker::visitInfixExpr(ast::InfixExpr *expr) {
+  Type leftTy = visitExpr(expr->getLeft());
+  Type rightTy = visitExpr(expr->getRight());
+
+  if (leftTy != rightTy) {
+    auto label = diag::Label::primary(
+        expr->getRight()->getSpanStart(), expr->getRight()->getSpanEnd(),
+        llvm::formatv("expected type `{0}`, found type `{1}`", tyToStr(leftTy),
+                      tyToStr(rightTy)));
+    diagEngine.print(
+        diag::Diagnostic::error("mismatched type").withLabel(label));
+  }
+
+  switch (expr->getInfixOp()) {
+  case lexer::TokenKind::Eq:
+  case lexer::TokenKind::Ne:
+  case lexer::TokenKind::Lt:
+  case lexer::TokenKind::Le:
+  case lexer::TokenKind::Gt:
+  case lexer::TokenKind::Ge:
+    return Type::Boolean;
+
+  case lexer::TokenKind::And:
+  case lexer::TokenKind::Or: {
+    if (leftTy != Type::Boolean) {
+      auto label = diag::Label::primary(
+          expr->getLeft()->getSpanStart(), expr->getLeft()->getSpanEnd(),
+          llvm::formatv("expected type `Boolean`, found type `{0}`",
+                        tyToStr(leftTy)));
+      diagEngine.print(
+          diag::Diagnostic::error("mismatched type").withLabel(label));
+    }
+    return Type::Boolean;
+  }
+
+  default:
+    return leftTy;
+  }
+}
+
+Type TypeChecker::visitBlockExpr(ast::BlockExpr *expr) {
+  Type lastTy = Type::None;
+  for (ast::Stmt *stmt : expr->getStmts()) {
+    lastTy = visitStmt(stmt);
+  }
+  return lastTy;
+}
+
+Type TypeChecker::visitIfExpr(ast::IfExpr *expr) {
+  checkExpr(expr->getCond(), Type::Boolean);
+  Type consequenceTy = visitBlockExpr(expr->getThen());
+
+  if (ast::Expr *altExpr = expr->getAlt()) {
+    Type alternativeTy = visitExpr(altExpr);
+    if (consequenceTy != alternativeTy) {
+      auto label = diag::Label::primary(
+          altExpr->getSpanStart(), altExpr->getSpanEnd(),
+          llvm::formatv("expected type `{0}`, found type `{1}`",
+                        tyToStr(consequenceTy), tyToStr(alternativeTy)));
+      diagEngine.print(
+          diag::Diagnostic::error("mismatched type").withLabel(label));
+    }
+    return consequenceTy;
+  }
+  return Type::None;
+}
+
+Type TypeChecker::visitVarDecl(ast::VarDecl *decl) {
+  std::optional<Type> explicitTy;
+  if (!decl->getExplicitType().empty()) {
+    explicitTy = strToTy(decl->getExplicitType());
+  }
+
+  Type rhsTy = Type::None;
+  if (explicitTy.has_value()) {
+    if (ast::Expr *value = decl->getValue()) {
+      checkExpr(value, explicitTy.value());
+    }
+    rhsTy = explicitTy.value();
+  } else {
+    if (ast::Expr *value = decl->getValue()) {
+      rhsTy = visitExpr(value);
+    } else {
+      rhsTy = Type::None;
+    }
+  }
+
+  env[decl->getName()] = rhsTy;
+  return rhsTy;
+}
+
+Type TypeChecker::visitDeclStmt(ast::DeclStmt *stmt) {
+  return visitDecl(stmt->getDecl());
+}
+
+Type TypeChecker::visitExprStmt(ast::ExprStmt *stmt) {
+  return visitExpr(stmt->getExpr());
+}
+
+std::string TypeChecker::tyToStr(Type ty) const {
+  switch (ty) {
+  case Type::String:
+    return "String";
+  case Type::Integer:
+    return "Integer";
+  case Type::Float:
+    return "Float";
+  case Type::Boolean:
+    return "Boolean";
+  case Type::None:
+    return "None";
+  }
+  return "None";
+}
+
+Type TypeChecker::strToTy(llvm::StringRef str) const {
+  if (str == "String")
+    return Type::String;
+  if (str == "Int")
+    return Type::Integer;
+  if (str == "Float")
+    return Type::Float;
+  if (str == "Bool")
+    return Type::Boolean;
+  return Type::None;
+}
+
+} // namespace birgen
+} // namespace belalang

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -31,6 +31,29 @@ cc_library(
 )
 
 # ------------------------------------------------------------------------------
+# BIRGen
+# ------------------------------------------------------------------------------
+
+cc_library(
+    name = "BIRGen",
+    srcs = [
+        "BIRGen/BIRGen.cpp",
+        "BIRGen/TypeChecker.cpp",
+    ],
+    deps = [
+        "//include:AST",
+        "//include:BIR",
+        "//include:BIRGen",
+        "//include:Diag",
+        "//include:Lexer",
+        "//bir",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+# ------------------------------------------------------------------------------
 # Diag
 # ------------------------------------------------------------------------------
 

--- a/tests/BIRGen/BUILD.bazel
+++ b/tests/BIRGen/BUILD.bazel
@@ -6,9 +6,9 @@ lit_test(
     name = "lit_test",
     tests = BELALANG_TESTS,
     data = [
-        "//bin/belalang",
+        "//bin/belalang:belalang-cc",
     ],
     env = {
-        "BELALANG": "$(rlocationpath //bin/belalang)",
+        "BELALANG": "$(rlocationpath //bin/belalang:belalang-cc)",
     },
 )

--- a/tools/bir-tblgen/CXXBindingDefs.cpp
+++ b/tools/bir-tblgen/CXXBindingDefs.cpp
@@ -31,7 +31,7 @@ void emitBuilderFunctionDef(OpMetadata M, llvm::raw_ostream &os) {
   auto op = M.getOp();
   auto args = getArgs(op);
 
-  os << retTy + " BIRGen::" + M.getBuilderName() + "(" + args + ") {\n";
+  os << retTy + " CxxBIRGen::" + M.getBuilderName() + "(" + args + ") {\n";
 
   if (op.getNumResults() > 0)
     os.indent(2) << "return nullptr;\n";

--- a/tools/bir-tblgen/RustBindings.cpp
+++ b/tools/bir-tblgen/RustBindings.cpp
@@ -14,7 +14,7 @@ void emitGuardClassesDecls(OpMetadata M, llvm::raw_ostream &os) {
 }
 
 void emitBuilderFunction(OpMetadata M, llvm::raw_ostream &os) {
-  os.indent(8) << "fn " + M.getBuilderName() << "(self: Pin<&mut BIRGen>)";
+  os.indent(8) << "fn " + M.getBuilderName() << "(self: Pin<&mut CxxBIRGen>)";
   if (M.requiresGuard())
     os << " -> UniquePtr<" + M.getGuardName() + ">";
   os << ";\n";
@@ -29,10 +29,10 @@ void emitRustBindingDecls(const llvm::RecordKeeper &rk, llvm::raw_ostream &os) {
 
   os.indent(4) << "unsafe extern \"C++\" {\n";
 
-  os.indent(8) << "include!(\"belalang/BIRGen/BIRGen.h\");\n";
-  os.indent(8) << "type BIRGen;\n";
+  os.indent(8) << "include!(\"belalang/BIRGen/CxxBIRGen.h\");\n";
+  os.indent(8) << "type CxxBIRGen;\n";
 
-  os.indent(8) << "fn create_birgen(gen_ptr: usize) -> UniquePtr<BIRGen>;\n";
+  os.indent(8) << "fn create_birgen(gen_ptr: usize) -> UniquePtr<CxxBIRGen>;\n";
 
   for (const auto *opRec : rk.getAllDerivedDefinitions("BIR_Op")) {
     mlir::tblgen::Operator op(opRec);


### PR DESCRIPTION
Part of #313 

Implementes the C++ rewrite of BIRGen. This also implements the TypeChecker as that is needed for some paths in the BIRGen.