### PR TITLE
[ast] Implement Types

### DIFF
--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -1,9 +1,9 @@
-#include "belalang/AST/Parser.h"
 #include "belalang/AST/ASTDumper.h"
+#include "belalang/AST/Parser.h"
 #include "belalang/BIRGen/BIRGen.h"
+#include "belalang/Diag/Diag.h"
 #include "belalang/LLVMGen/LLVMGen.h"
 #include "belalang/Lexer/Lexer.h"
-#include "belalang/Diag/Diag.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <iostream>
 #include <string>
@@ -105,8 +105,8 @@ int build(muopt::Parser &parser) {
       } else if (kind == lexer::TokenKind::Ident ||
                  kind == lexer::TokenKind::LiteralInteger ||
                  kind == lexer::TokenKind::LiteralFloat) {
-        std::cout << kindStr << " \"" << tok.getStr().str() << "\" <"
-                  << start << ".." << end << ">\n";
+        std::cout << kindStr << " \"" << tok.getStr().str() << "\" <" << start
+                  << ".." << end << ">\n";
       } else {
         std::cout << kindStr << " <" << start << ".." << end << ">\n";
       }
@@ -124,7 +124,7 @@ int build(muopt::Parser &parser) {
     ast::Program *prog = parser.parseProgram();
 
     if (prog) {
-      ast::ASTDumper dumper;
+      ast::ASTDumper dumper(astCtx);
       dumper.visitProgram(prog);
     }
 

--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -141,7 +141,7 @@ int build(muopt::Parser &parser) {
     if (!prog)
       return parser.hadError() ? 1 : 0;
 
-    birgen::BIRGen birgen(diagEngine);
+    birgen::BIRGen birgen(astCtx, diagEngine);
     birgen.generateProgram(prog);
 
     if (emit == EmitTarget::BirLowered && !birgen.runLoweringPipeline()) {
@@ -163,7 +163,7 @@ int build(muopt::Parser &parser) {
     if (!prog)
       return parser.hadError() ? 1 : 0;
 
-    birgen::BIRGen birgen(diagEngine);
+    birgen::BIRGen birgen(astCtx, diagEngine);
     birgen.generateProgram(prog);
 
     if (!birgen.runLoweringPipeline()) {

--- a/bin/belalang/CmdRun.cpp
+++ b/bin/belalang/CmdRun.cpp
@@ -38,7 +38,7 @@ int run(muopt::Parser &parser) {
   if (!prog)
     return astParser.hadError() ? 1 : 0;
 
-  birgen::BIRGen birgen(diagEngine);
+  birgen::BIRGen birgen(astCtx, diagEngine);
   birgen.generateProgram(prog);
 
   if (!birgen.runLoweringPipeline()) {

--- a/include/belalang/AST/ASTContext.h
+++ b/include/belalang/AST/ASTContext.h
@@ -1,6 +1,8 @@
 #ifndef BELALANG_AST_ASTCONTEXT_H_
 #define BELALANG_AST_ASTCONTEXT_H_
 
+#include "belalang/AST/Type.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
 
 namespace belalang {
@@ -9,8 +11,18 @@ namespace ast {
 class ASTContext {
   mutable llvm::BumpPtrAllocator allocator;
 
+  // ---------------------------------------------------------------------------
+  // Types
+  // ---------------------------------------------------------------------------
+
+  mutable llvm::SmallVector<Type *, 0> types;
+
 public:
-  ASTContext() = default;
+  ASTContext();
+
+  // ---------------------------------------------------------------------------
+  // Allocation goodies
+  // ---------------------------------------------------------------------------
 
   llvm::BumpPtrAllocator &getAllocator() const { return allocator; }
 
@@ -21,6 +33,26 @@ public:
     return static_cast<T *>(alloc(num * sizeof(T), alignof(T)));
   }
   void dealloc(void *ptr) const {}
+
+  // ---------------------------------------------------------------------------
+  // Builtin Types
+  // ---------------------------------------------------------------------------
+
+  void initBuiltinTypes();
+  void initBuiltinType(BuiltinType *&ty, BuiltinType::Kind kind);
+
+  BuiltinType *intTy;
+  BuiltinType *floatTy;
+  BuiltinType *boolTy;
+  BuiltinType *stringTy;
+  BuiltinType *noneTy;
+
+  // ---------------------------------------------------------------------------
+  // Type name conversions
+  // ---------------------------------------------------------------------------
+
+  llvm::StringRef tyToStr(Type *ty) const;
+  Type *strToTy(llvm::StringRef str) const;
 };
 
 } // namespace ast

--- a/include/belalang/AST/ASTDumper.h
+++ b/include/belalang/AST/ASTDumper.h
@@ -1,6 +1,7 @@
 #ifndef BELALANG_AST_ASTDUMPER_H_
 #define BELALANG_AST_ASTDUMPER_H_
 
+#include "belalang/AST/ASTContext.h"
 #include "belalang/AST/ASTVisitor.h"
 #include "belalang/AST/Program.h"
 #include "belalang/AST/Stmt.h"
@@ -10,6 +11,7 @@ namespace belalang {
 namespace ast {
 
 class ASTDumper : public ASTVisitor<ASTDumper> {
+  ASTContext &ctx;
   llvm::raw_ostream &out;
   uint64_t depth;
 
@@ -20,7 +22,8 @@ class ASTDumper : public ASTVisitor<ASTDumper> {
   };
 
 public:
-  ASTDumper(llvm::raw_ostream &out = llvm::outs()) : out(out), depth(0) {}
+  ASTDumper(ASTContext &ctx, llvm::raw_ostream &out = llvm::outs())
+      : ctx(ctx), out(out), depth(0) {}
 
   void visitProgram(Program *prog);
 

--- a/include/belalang/AST/Decl.h
+++ b/include/belalang/AST/Decl.h
@@ -61,11 +61,11 @@ private:
 class VarDecl : public Decl {
   llvm::StringRef name;
   Expr *value;
-  llvm::StringRef explicitType;
+  Type *explicitType;
 
 public:
   VarDecl(size_t spanStart, size_t spanEnd, llvm::StringRef name, Expr *value,
-          llvm::StringRef explicitType)
+          Type *explicitType)
       : Decl(DeclKind::VarDecl, spanStart, spanEnd), name(name), value(value),
         explicitType(explicitType) {}
 
@@ -75,7 +75,7 @@ public:
 
   llvm::StringRef getName() const { return name; }
   Expr *getValue() const { return value; }
-  llvm::StringRef getExplicitType() const { return explicitType; }
+  Type *getExplicitType() const { return explicitType; }
 };
 
 /// Represents struct declaration, e.g. `struct T { ... }`

--- a/include/belalang/AST/Expr.h
+++ b/include/belalang/AST/Expr.h
@@ -176,12 +176,12 @@ public:
 class FunctionLitExpr : public Expr {
   llvm::ArrayRef<VarDecl *> params;
   BlockExpr *body;
-  llvm::StringRef explicitType;
+  ast::Type *explicitType;
 
 public:
   FunctionLitExpr(size_t spanStart, size_t spanEnd,
                   llvm::ArrayRef<VarDecl *> params, BlockExpr *body,
-                  llvm::StringRef explicitType)
+                  ast::Type *explicitType)
       : Expr(ExprKind::FunctionLitExpr, spanStart, spanEnd), params(params),
         body(body), explicitType(explicitType) {}
 
@@ -191,7 +191,7 @@ public:
 
   llvm::ArrayRef<VarDecl *> getParams() const { return params; }
   BlockExpr *getBody() const { return body; }
-  llvm::StringRef getExplicitType() const { return explicitType; }
+  ast::Type *getExplicitType() const { return explicitType; }
 };
 
 /// Represents call expression, e.g. `function_name()`

--- a/include/belalang/AST/Type.h
+++ b/include/belalang/AST/Type.h
@@ -1,0 +1,48 @@
+#ifndef BELALANG_AST_TYPE_H_
+#define BELALANG_AST_TYPE_H_
+
+namespace belalang {
+namespace ast {
+
+class Type {
+public:
+  Type() = delete;
+  Type(const Type &) = delete;
+  Type(Type &&) = delete;
+  Type &operator=(const Type &) = delete;
+  Type &operator=(Type &&) = delete;
+
+  enum class TypeKind {
+    Builtin,
+  };
+
+  TypeKind getKind() const { return kind; }
+
+protected:
+  Type(TypeKind k) : kind(k) {}
+
+private:
+  TypeKind kind;
+};
+
+class BuiltinType : public Type {
+public:
+  enum class Kind {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    None,
+  };
+
+  BuiltinType(Kind k) : Type(TypeKind::Builtin) {}
+
+  static bool classof(const Type *t) {
+    return t->getKind() == TypeKind::Builtin;
+  }
+};
+
+} // namespace ast
+} // namespace belalang
+
+#endif // BELALANG_AST_TYPE_H_

--- a/include/belalang/BIRGen/BIRGen.h
+++ b/include/belalang/BIRGen/BIRGen.h
@@ -1,6 +1,7 @@
 #ifndef BELALANG_BIRGEN_BIRGEN_H_
 #define BELALANG_BIRGEN_BIRGEN_H_
 
+#include "belalang/AST/ASTContext.h"
 #include "belalang/AST/ASTVisitor.h"
 #include "belalang/BIRGen/TypeChecker.h"
 #include "belalang/Diag/Diag.h"
@@ -15,7 +16,7 @@ namespace birgen {
 
 class BIRGen : public ast::ASTVisitor<BIRGen, mlir::Value> {
 public:
-  BIRGen(diag::DiagnosticEngine &diagEngine);
+  BIRGen(ast::ASTContext &ctx, diag::DiagnosticEngine &diagEngine);
   ~BIRGen() = default;
 
   uintptr_t getModulePtr() const {

--- a/include/belalang/BIRGen/BIRGen.h
+++ b/include/belalang/BIRGen/BIRGen.h
@@ -33,12 +33,13 @@ public:
 #include "belalang/AST/ASTNodes.def"
 
 private:
+  ast::ASTContext &astCtx;
   diag::DiagnosticEngine &diagEngine;
   TypeChecker typeChecker;
   llvm::StringMap<mlir::Value> symbolTable;
 
   void buildMainReturn();
-  mlir::Type mapTypeName(llvm::StringRef name);
+  mlir::Type mapTypeName(ast::Type *ty);
 
   mlir::MLIRContext context;
   mlir::ModuleOp module;

--- a/include/belalang/BIRGen/TypeChecker.h
+++ b/include/belalang/BIRGen/TypeChecker.h
@@ -1,50 +1,37 @@
 #ifndef BELALANG_BIRGEN_TYPECHECKER_H_
 #define BELALANG_BIRGEN_TYPECHECKER_H_
 
-#include "belalang/AST/ASTVisitor.h"
 #include "belalang/AST/ASTContext.h"
+#include "belalang/AST/ASTVisitor.h"
 #include "belalang/Diag/Diag.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/StringRef.h"
-#include <string>
 
 namespace belalang {
 namespace birgen {
 
-enum class Type {
-  String,
-  Integer,
-  Float,
-  Boolean,
-  None,
-};
-
-class TypeChecker : public ast::ASTVisitor<TypeChecker, Type> {
+class TypeChecker : public ast::ASTVisitor<TypeChecker, ast::Type *> {
 public:
-  TypeChecker(ast::ASTContext ctx, diag::DiagnosticEngine &diagEngine);
+  TypeChecker(ast::ASTContext &ctx, diag::DiagnosticEngine &diagEngine);
 
   void infer(ast::Program *prog);
-  void checkExpr(ast::Expr *expr, Type expected);
+  void checkExpr(ast::Expr *expr, ast::Type *expected);
 
-  Type visitIntLitExpr(ast::IntLitExpr *expr);
-  Type visitFloatLitExpr(ast::FloatLitExpr *expr);
-  Type visitStringLitExpr(ast::StringLitExpr *expr);
-  Type visitBoolExpr(ast::BoolExpr *expr);
-  Type visitIdentifierExpr(ast::IdentifierExpr *expr);
-  Type visitInfixExpr(ast::InfixExpr *expr);
-  Type visitBlockExpr(ast::BlockExpr *expr);
-  Type visitIfExpr(ast::IfExpr *expr);
-  Type visitVarDecl(ast::VarDecl *decl);
-  Type visitDeclStmt(ast::DeclStmt *stmt);
-  Type visitExprStmt(ast::ExprStmt *stmt);
+  ast::Type *visitIntLitExpr(ast::IntLitExpr *expr);
+  ast::Type *visitFloatLitExpr(ast::FloatLitExpr *expr);
+  ast::Type *visitStringLitExpr(ast::StringLitExpr *expr);
+  ast::Type *visitBoolExpr(ast::BoolExpr *expr);
+  ast::Type *visitIdentifierExpr(ast::IdentifierExpr *expr);
+  ast::Type *visitInfixExpr(ast::InfixExpr *expr);
+  ast::Type *visitBlockExpr(ast::BlockExpr *expr);
+  ast::Type *visitIfExpr(ast::IfExpr *expr);
+  ast::Type *visitVarDecl(ast::VarDecl *decl);
+  ast::Type *visitDeclStmt(ast::DeclStmt *stmt);
+  ast::Type *visitExprStmt(ast::ExprStmt *stmt);
 
 private:
-  ast::ASTContext ctx;
+  ast::ASTContext &ctx;
   diag::DiagnosticEngine &diagEngine;
-  llvm::StringMap<Type> env;
-
-  std::string tyToStr(Type ty) const;
-  Type strToTy(llvm::StringRef str) const;
+  llvm::StringMap<ast::Type *> env;
 };
 
 } // namespace birgen

--- a/include/belalang/BIRGen/TypeChecker.h
+++ b/include/belalang/BIRGen/TypeChecker.h
@@ -2,6 +2,7 @@
 #define BELALANG_BIRGEN_TYPECHECKER_H_
 
 #include "belalang/AST/ASTVisitor.h"
+#include "belalang/AST/ASTContext.h"
 #include "belalang/Diag/Diag.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -20,7 +21,7 @@ enum class Type {
 
 class TypeChecker : public ast::ASTVisitor<TypeChecker, Type> {
 public:
-  TypeChecker(diag::DiagnosticEngine &diagEngine);
+  TypeChecker(ast::ASTContext ctx, diag::DiagnosticEngine &diagEngine);
 
   void infer(ast::Program *prog);
   void checkExpr(ast::Expr *expr, Type expected);
@@ -38,6 +39,7 @@ public:
   Type visitExprStmt(ast::ExprStmt *stmt);
 
 private:
+  ast::ASTContext ctx;
   diag::DiagnosticEngine &diagEngine;
   llvm::StringMap<Type> env;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1,0 +1,52 @@
+#include "belalang/AST/ASTContext.h"
+
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/Casting.h"
+
+namespace belalang {
+namespace ast {
+
+ASTContext::ASTContext() { initBuiltinTypes(); }
+
+void ASTContext::initBuiltinType(BuiltinType *&r, BuiltinType::Kind kind) {
+  auto *ty = new (*this) BuiltinType(kind);
+  r = ty;
+  types.push_back(ty);
+}
+
+void ASTContext::initBuiltinTypes() {
+  initBuiltinType(intTy, BuiltinType::Kind::Integer);
+  initBuiltinType(floatTy, BuiltinType::Kind::Float);
+  initBuiltinType(boolTy, BuiltinType::Kind::Boolean);
+  initBuiltinType(stringTy, BuiltinType::Kind::String);
+  initBuiltinType(noneTy, BuiltinType::Kind::None);
+}
+
+llvm::StringRef ASTContext::tyToStr(Type *ty) const {
+  if (auto *builtinTy = llvm::dyn_cast<BuiltinType>(ty)) {
+    if (builtinTy == stringTy)
+      return "String";
+    if (builtinTy == intTy)
+      return "Int";
+    if (builtinTy == floatTy)
+      return "Float";
+    if (builtinTy == boolTy)
+      return "Bool";
+    if (builtinTy == noneTy)
+      return "None";
+  }
+  return "None";
+}
+
+Type *ASTContext::strToTy(llvm::StringRef str) const {
+  return llvm::StringSwitch<Type *>(str)
+      .Case("Int", intTy)
+      .Case("Float", floatTy)
+      .Case("String", stringTy)
+      .Case("Bool", boolTy)
+      .Case("None", noneTy)
+      .Default(noneTy);
+}
+
+} // namespace ast
+} // namespace belalang

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1,5 +1,5 @@
 #include "belalang/AST/ASTDumper.h"
-#include "belalang/Lexer/Token.h" // For TokenKind
+#include "belalang/Lexer/Token.h"
 
 // This is the ASTDumper implementation. For verbosity, we made every use of
 // IndentGuard in its own block. This is not technically needed, but helps with
@@ -105,8 +105,8 @@ void ASTDumper::visitVarExpr(VarExpr *expr) {
 
 void ASTDumper::visitFunctionLitExpr(FunctionLitExpr *expr) {
   out.indent(depth) << "FunctionLitExpr";
-  if (!expr->getExplicitType().empty()) {
-    out << " -> " << expr->getExplicitType();
+  if (expr->getExplicitType()) {
+    out << " -> " << ctx.tyToStr(expr->getExplicitType());
   }
   out << "\n";
   {
@@ -203,8 +203,8 @@ void ASTDumper::visitStructLiteralExpr(StructLiteralExpr *expr) {
 
 void ASTDumper::visitVarDecl(VarDecl *decl) {
   out.indent(depth) << "VarDecl " << decl->getName();
-  if (!decl->getExplicitType().empty()) {
-    out << " " << decl->getExplicitType();
+  if (decl->getExplicitType()) {
+    out << " " << ctx.tyToStr(decl->getExplicitType());
   }
   out << "\n";
   if (decl->getValue()) {

--- a/lib/AST/Parser.cpp
+++ b/lib/AST/Parser.cpp
@@ -1,4 +1,6 @@
 #include "belalang/AST/Parser.h"
+#include "belalang/AST/ASTContext.h"
+#include "belalang/AST/Type.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace belalang {
@@ -28,8 +30,8 @@ bool Parser::tryConsumeToken(lexer::TokenKind expectedTok) {
 void Parser::errorAt(size_t spanStart, size_t spanEnd, std::string message,
                      std::string label) {
   diagEngine.print(diag::Diagnostic::error(std::move(message))
-                       .withLabel(diag::Label::primary(
-                           spanStart, spanEnd, std::move(label))));
+                       .withLabel(diag::Label::primary(spanStart, spanEnd,
+                                                       std::move(label))));
   hasError = true;
 }
 
@@ -483,13 +485,10 @@ Expr *Parser::parseFunctionLitExpr() {
       return nullptr;
     }
 
-    llvm::StringRef typeName = tok.getStr();
-    char *typeData = c.alloc<char>(typeName.size());
-    std::copy(typeName.begin(), typeName.end(), typeData);
-    typeName = llvm::StringRef(typeData, typeName.size());
+    Type *ty = c.strToTy(tok.getStr());
 
     size_t end = tok.getSpanEnd();
-    params.push_back(new (c) VarDecl(start, end, name, nullptr, typeName));
+    params.push_back(new (c) VarDecl(start, end, name, nullptr, ty));
     consumeToken(); // consume type
 
     if (tryConsumeToken(lexer::TokenKind::RightParen))
@@ -504,12 +503,9 @@ Expr *Parser::parseFunctionLitExpr() {
   if (tok.getKind() == lexer::TokenKind::RightParen)
     consumeToken();
 
-  llvm::StringRef type;
+  ast::Type *type = nullptr;
   if (tryConsumeToken(lexer::TokenKind::Colon)) {
-    llvm::StringRef typeStr = tok.getStr();
-    char *strData = c.alloc<char>(typeStr.size());
-    std::copy(typeStr.begin(), typeStr.end(), strData);
-    type = llvm::StringRef(strData, typeStr.size());
+    type = c.strToTy(tok.getStr());
     consumeToken(); // consume type name
   }
 
@@ -618,7 +614,6 @@ Expr *Parser::parseIfExpr() {
 
   return new (c) IfExpr(start, end, cond, then, alt);
 }
-
 
 Expr *Parser::parseInfixExpr(Expr *left) {
   size_t start = left->getSpanStart();
@@ -743,9 +738,9 @@ Expr *Parser::parseStructLiteralExpr(Expr *left) {
   VarExpr **fieldsData = c.alloc<VarExpr *>(fields.size());
   std::copy(fields.begin(), fields.end(), fieldsData);
 
-  return new (c) StructLiteralExpr(
-      start, end, structName,
-      llvm::ArrayRef<VarExpr *>(fieldsData, fields.size()));
+  return new (c)
+      StructLiteralExpr(start, end, structName,
+                        llvm::ArrayRef<VarExpr *>(fieldsData, fields.size()));
 }
 
 Expr *Parser::parseGroupedExpr() {
@@ -795,14 +790,11 @@ Decl *Parser::parseVarDecl() {
   consumeToken(); // consume the identifier
   consumeToken(); // consume `:`
 
-  llvm::StringRef explicitType;
+  ast::Type *explicitType = nullptr;
   if (tok.getKind() == lexer::TokenKind::Assign) {
     // `name := value`; no explicit type, `tok` is the `=`.
   } else if (tok.getKind() == lexer::TokenKind::Ident) {
-    explicitType = tok.getStr();
-    char *typeData = c.alloc<char>(explicitType.size());
-    std::copy(explicitType.begin(), explicitType.end(), typeData);
-    explicitType = llvm::StringRef(typeData, explicitType.size());
+    explicitType = c.strToTy(tok.getStr());
     consumeToken(); // consume the type name
   } else {
     errorAt(tok.getSpanStart(), tok.getSpanEnd(), "unexpected token");
@@ -863,13 +855,10 @@ Decl *Parser::parseStructDecl() {
       return nullptr;
     }
 
-    llvm::StringRef typeName = tok.getStr();
-    char *typeData = c.alloc<char>(typeName.size());
-    std::copy(typeName.begin(), typeName.end(), typeData);
-    typeName = llvm::StringRef(typeData, typeName.size());
+    ast::Type *ty = c.strToTy(tok.getStr());
 
     size_t end = tok.getSpanEnd();
-    members.push_back(new (c) VarDecl(start, end, name, nullptr, typeName));
+    members.push_back(new (c) VarDecl(start, end, name, nullptr, ty));
     consumeToken(); // consume type
 
     structEnd = tok.getSpanEnd();

--- a/lib/BIRGen/BIRGen.cpp
+++ b/lib/BIRGen/BIRGen.cpp
@@ -22,8 +22,8 @@ using namespace ast;
 using namespace lexer;
 
 BIRGen::BIRGen(ast::ASTContext &ctx, diag::DiagnosticEngine &diagEngine)
-    : diagEngine(diagEngine), typeChecker(ctx, diagEngine), builder(&context),
-      loc(builder.getUnknownLoc()) {
+    : astCtx(ctx), diagEngine(diagEngine), typeChecker(ctx, diagEngine),
+      builder(&context), loc(builder.getUnknownLoc()) {
   // Load dialects.
   mlir::DialectRegistry registry;
   registry.insert<bir::BIRDialect, mlir::LLVM::LLVMDialect>();
@@ -52,32 +52,19 @@ mlir::ModuleOp BIRGen::generateProgram(Program *prog) {
 // Helpers
 // -----------------------------------------------------------------------------
 
-mlir::Type BIRGen::mapTypeName(llvm::StringRef name) {
-  if (name == "String")
-    return bir::StringType::get(&context);
-  if (name == "Int")
-    return bir::IntType::get(&context);
-  if (name == "Float")
-    return bir::FloatType::get(&context);
-  if (name == "Bool")
-    return bir::BoolType::get(&context);
-
-  llvm_unreachable("unknown type");
-}
-
-static mlir::Type mapType(mlir::MLIRContext *context, Type ty) {
-  switch (ty) {
-  case Type::Integer:
-    return bir::IntType::get(context);
-  case Type::Boolean:
-    return bir::BoolType::get(context);
-  case Type::String:
-    return bir::StringType::get(context);
-  case Type::Float:
-    return bir::FloatType::get(context);
-  default:
-    return nullptr;
+mlir::Type BIRGen::mapTypeName(Type *ty) {
+  if (auto *builtinTy = llvm::dyn_cast<BuiltinType>(ty)) {
+    if (builtinTy == astCtx.stringTy)
+      return bir::StringType::get(&context);
+    if (builtinTy == astCtx.intTy)
+      return bir::IntType::get(&context);
+    if (builtinTy == astCtx.floatTy)
+      return bir::FloatType::get(&context);
+    if (builtinTy == astCtx.boolTy)
+      return bir::BoolType::get(&context);
   }
+
+  return {};
 }
 
 namespace {
@@ -269,7 +256,7 @@ mlir::Value BIRGen::visitVarExpr(VarExpr *expr) {
 }
 
 mlir::Value BIRGen::visitFunctionLitExpr(FunctionLitExpr *expr) {
-  if (expr->getExplicitType().empty())
+  if (!expr->getExplicitType())
     llvm_unreachable("not yet implemented");
 
   mlir::Type ty = mapTypeName(expr->getExplicitType());
@@ -352,10 +339,10 @@ mlir::Value BIRGen::visitIdentifierExpr(IdentifierExpr *expr) {
 mlir::Value BIRGen::visitIfExpr(IfExpr *expr) {
   mlir::Value cond = visitExpr(expr->getCond());
 
-  Type inferredTy = typeChecker.visitIfExpr(expr);
+  ast::Type *inferredTy = typeChecker.visitIfExpr(expr);
   llvm::SmallVector<mlir::Type, 1> resultTypes;
-  if (inferredTy != Type::None) {
-    if (auto ty = mapType(&context, inferredTy)) {
+  if (inferredTy != astCtx.noneTy) {
+    if (auto ty = mapTypeName(inferredTy)) {
       resultTypes.push_back(ty);
     }
   }
@@ -420,10 +407,10 @@ mlir::Value BIRGen::visitPrefixExpr(PrefixExpr *expr) {
 }
 
 mlir::Value BIRGen::visitBlockExpr(BlockExpr *expr) {
-  Type inferredTy = typeChecker.visitBlockExpr(expr);
+  ast::Type *inferredTy = typeChecker.visitBlockExpr(expr);
   llvm::SmallVector<mlir::Type, 1> resultTypes;
-  if (inferredTy != Type::None) {
-    if (auto ty = mapType(&context, inferredTy)) {
+  if (inferredTy != astCtx.noneTy) {
+    if (auto ty = mapTypeName(inferredTy)) {
       resultTypes.push_back(ty);
     }
   }

--- a/lib/BIRGen/BIRGen.cpp
+++ b/lib/BIRGen/BIRGen.cpp
@@ -1,5 +1,6 @@
 #include "belalang/BIRGen/BIRGen.h"
 
+#include "belalang/AST/ASTContext.h"
 #include "belalang/AST/Decl.h"
 #include "belalang/AST/Expr.h"
 #include "belalang/AST/Stmt.h"
@@ -20,8 +21,8 @@ namespace birgen {
 using namespace ast;
 using namespace lexer;
 
-BIRGen::BIRGen(diag::DiagnosticEngine &diagEngine)
-    : diagEngine(diagEngine), typeChecker(diagEngine), builder(&context),
+BIRGen::BIRGen(ast::ASTContext &ctx, diag::DiagnosticEngine &diagEngine)
+    : diagEngine(diagEngine), typeChecker(ctx, diagEngine), builder(&context),
       loc(builder.getUnknownLoc()) {
   // Load dialects.
   mlir::DialectRegistry registry;

--- a/lib/BIRGen/TypeChecker.cpp
+++ b/lib/BIRGen/TypeChecker.cpp
@@ -5,59 +5,61 @@
 #include "belalang/AST/Stmt.h"
 #include "belalang/Diag/Diag.h"
 #include "llvm/Support/FormatVariadic.h"
-#include <optional>
 
 namespace belalang {
 namespace birgen {
 
-TypeChecker::TypeChecker(ast::ASTContext ctx, diag::DiagnosticEngine &diagEngine)
+TypeChecker::TypeChecker(ast::ASTContext &ctx,
+                         diag::DiagnosticEngine &diagEngine)
     : ctx(ctx), diagEngine(diagEngine) {}
 
 void TypeChecker::infer(ast::Program *prog) { visitProgram(prog); }
 
-void TypeChecker::checkExpr(ast::Expr *expr, Type expected) {
-  Type inferred = visitExpr(expr);
+void TypeChecker::checkExpr(ast::Expr *expr, ast::Type *expected) {
+  ast::Type *inferred = visitExpr(expr);
   if (inferred != expected) {
     auto label = diag::Label::primary(
         expr->getSpanStart(), expr->getSpanEnd(),
         llvm::formatv("expected type `{0}`, found type `{1}`",
-                      tyToStr(expected), tyToStr(inferred)));
+                      ctx.tyToStr(expected), ctx.tyToStr(inferred)));
     diagEngine.print(
         diag::Diagnostic::error("mismatched type").withLabel(label));
   }
 }
 
-Type TypeChecker::visitIntLitExpr(ast::IntLitExpr *expr) {
-  return Type::Integer;
+ast::Type *TypeChecker::visitIntLitExpr(ast::IntLitExpr *expr) {
+  return ctx.intTy;
 }
 
-Type TypeChecker::visitFloatLitExpr(ast::FloatLitExpr *expr) {
-  return Type::Float;
+ast::Type *TypeChecker::visitFloatLitExpr(ast::FloatLitExpr *expr) {
+  return ctx.floatTy;
 }
 
-Type TypeChecker::visitStringLitExpr(ast::StringLitExpr *expr) {
-  return Type::String;
+ast::Type *TypeChecker::visitStringLitExpr(ast::StringLitExpr *expr) {
+  return ctx.stringTy;
 }
 
-Type TypeChecker::visitBoolExpr(ast::BoolExpr *expr) { return Type::Boolean; }
+ast::Type *TypeChecker::visitBoolExpr(ast::BoolExpr *expr) {
+  return ctx.boolTy;
+}
 
-Type TypeChecker::visitIdentifierExpr(ast::IdentifierExpr *expr) {
+ast::Type *TypeChecker::visitIdentifierExpr(ast::IdentifierExpr *expr) {
   auto it = env.find(expr->getName());
   if (it != env.end()) {
     return it->second;
   }
-  return Type::None;
+  return ctx.noneTy;
 }
 
-Type TypeChecker::visitInfixExpr(ast::InfixExpr *expr) {
-  Type leftTy = visitExpr(expr->getLeft());
-  Type rightTy = visitExpr(expr->getRight());
+ast::Type *TypeChecker::visitInfixExpr(ast::InfixExpr *expr) {
+  ast::Type *leftTy = visitExpr(expr->getLeft());
+  ast::Type *rightTy = visitExpr(expr->getRight());
 
   if (leftTy != rightTy) {
     auto label = diag::Label::primary(
         expr->getRight()->getSpanStart(), expr->getRight()->getSpanEnd(),
-        llvm::formatv("expected type `{0}`, found type `{1}`", tyToStr(leftTy),
-                      tyToStr(rightTy)));
+        llvm::formatv("expected type `{0}`, found type `{1}`",
+                      ctx.tyToStr(leftTy), ctx.tyToStr(rightTy)));
     diagEngine.print(
         diag::Diagnostic::error("mismatched type").withLabel(label));
   }
@@ -69,19 +71,19 @@ Type TypeChecker::visitInfixExpr(ast::InfixExpr *expr) {
   case lexer::TokenKind::Le:
   case lexer::TokenKind::Gt:
   case lexer::TokenKind::Ge:
-    return Type::Boolean;
+    return ctx.boolTy;
 
   case lexer::TokenKind::And:
   case lexer::TokenKind::Or: {
-    if (leftTy != Type::Boolean) {
+    if (leftTy != ctx.boolTy) {
       auto label = diag::Label::primary(
           expr->getLeft()->getSpanStart(), expr->getLeft()->getSpanEnd(),
           llvm::formatv("expected type `Boolean`, found type `{0}`",
-                        tyToStr(leftTy)));
+                        ctx.tyToStr(leftTy)));
       diagEngine.print(
           diag::Diagnostic::error("mismatched type").withLabel(label));
     }
-    return Type::Boolean;
+    return ctx.boolTy;
   }
 
   default:
@@ -89,50 +91,48 @@ Type TypeChecker::visitInfixExpr(ast::InfixExpr *expr) {
   }
 }
 
-Type TypeChecker::visitBlockExpr(ast::BlockExpr *expr) {
-  Type lastTy = Type::None;
+ast::Type *TypeChecker::visitBlockExpr(ast::BlockExpr *expr) {
+  ast::Type *lastTy = ctx.noneTy;
   for (ast::Stmt *stmt : expr->getStmts()) {
     lastTy = visitStmt(stmt);
   }
   return lastTy;
 }
 
-Type TypeChecker::visitIfExpr(ast::IfExpr *expr) {
-  checkExpr(expr->getCond(), Type::Boolean);
-  Type consequenceTy = visitBlockExpr(expr->getThen());
+ast::Type *TypeChecker::visitIfExpr(ast::IfExpr *expr) {
+  checkExpr(expr->getCond(), ctx.boolTy);
+  ast::Type *consequenceTy = visitBlockExpr(expr->getThen());
 
   if (ast::Expr *altExpr = expr->getAlt()) {
-    Type alternativeTy = visitExpr(altExpr);
+    ast::Type *alternativeTy = visitExpr(altExpr);
     if (consequenceTy != alternativeTy) {
       auto label = diag::Label::primary(
           altExpr->getSpanStart(), altExpr->getSpanEnd(),
           llvm::formatv("expected type `{0}`, found type `{1}`",
-                        tyToStr(consequenceTy), tyToStr(alternativeTy)));
+                        ctx.tyToStr(consequenceTy),
+                        ctx.tyToStr(alternativeTy)));
       diagEngine.print(
           diag::Diagnostic::error("mismatched type").withLabel(label));
     }
     return consequenceTy;
   }
-  return Type::None;
+  return ctx.noneTy;
 }
 
-Type TypeChecker::visitVarDecl(ast::VarDecl *decl) {
-  std::optional<Type> explicitTy;
-  if (!decl->getExplicitType().empty()) {
-    explicitTy = strToTy(decl->getExplicitType());
-  }
+ast::Type *TypeChecker::visitVarDecl(ast::VarDecl *decl) {
+  ast::Type *explicitTy = decl->getExplicitType();
 
-  Type rhsTy = Type::None;
-  if (explicitTy.has_value()) {
+  ast::Type *rhsTy = ctx.noneTy;
+  if (explicitTy) {
     if (ast::Expr *value = decl->getValue()) {
-      checkExpr(value, explicitTy.value());
+      checkExpr(value, explicitTy);
     }
-    rhsTy = explicitTy.value();
+    rhsTy = explicitTy;
   } else {
     if (ast::Expr *value = decl->getValue()) {
       rhsTy = visitExpr(value);
     } else {
-      rhsTy = Type::None;
+      rhsTy = ctx.noneTy;
     }
   }
 
@@ -140,40 +140,12 @@ Type TypeChecker::visitVarDecl(ast::VarDecl *decl) {
   return rhsTy;
 }
 
-Type TypeChecker::visitDeclStmt(ast::DeclStmt *stmt) {
+ast::Type *TypeChecker::visitDeclStmt(ast::DeclStmt *stmt) {
   return visitDecl(stmt->getDecl());
 }
 
-Type TypeChecker::visitExprStmt(ast::ExprStmt *stmt) {
+ast::Type *TypeChecker::visitExprStmt(ast::ExprStmt *stmt) {
   return visitExpr(stmt->getExpr());
-}
-
-std::string TypeChecker::tyToStr(Type ty) const {
-  switch (ty) {
-  case Type::String:
-    return "String";
-  case Type::Integer:
-    return "Integer";
-  case Type::Float:
-    return "Float";
-  case Type::Boolean:
-    return "Boolean";
-  case Type::None:
-    return "None";
-  }
-  return "None";
-}
-
-Type TypeChecker::strToTy(llvm::StringRef str) const {
-  if (str == "String")
-    return Type::String;
-  if (str == "Int")
-    return Type::Integer;
-  if (str == "Float")
-    return Type::Float;
-  if (str == "Bool")
-    return Type::Boolean;
-  return Type::None;
 }
 
 } // namespace birgen

--- a/lib/BIRGen/TypeChecker.cpp
+++ b/lib/BIRGen/TypeChecker.cpp
@@ -10,8 +10,8 @@
 namespace belalang {
 namespace birgen {
 
-TypeChecker::TypeChecker(diag::DiagnosticEngine &diagEngine)
-    : diagEngine(diagEngine) {}
+TypeChecker::TypeChecker(ast::ASTContext ctx, diag::DiagnosticEngine &diagEngine)
+    : ctx(ctx), diagEngine(diagEngine) {}
 
 void TypeChecker::infer(ast::Program *prog) { visitProgram(prog); }
 


### PR DESCRIPTION
Closes #323 

This change replaces the rigid Type enum class with a hierarchical Type structure similar to how Decl, Expr, and Stmt works. The implementation took a lot of inspirations from Clang.