### PR TITLE
[bir] Implement struct attribute and its lowering

### DIFF
--- a/include/belalang/BIR/IR/BIRAttrs.td
+++ b/include/belalang/BIR/IR/BIRAttrs.td
@@ -45,6 +45,18 @@ def BIR_StringAttr : BIR_Attr<"String", "string", [TypedAttrInterface]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def BIR_StructAttr : BIR_Attr<"Struct", "struct", [TypedAttrInterface]> {
+  let summary = "An attribute containing a struct value";
+
+  let parameters = (ins
+    AttributeSelfTypeParameter<"">:$type,
+    ArrayRefParameter<"mlir::Attribute", "">:$members,
+    ArrayRefParameter<"mlir::Type", "">:$memberTypes
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 def BIR_FnAttr : BIR_Attr<"Fn", "fn", [TypedAttrInterface]> {
   let summary = "function";
 

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -22,7 +22,8 @@ def BIR_AnyType : AnyTypeOf<[
   BIR_FloatType,
   BIR_StringType,
   FunctionType,
-  BIR_BoolType
+  BIR_BoolType,
+  BIR_StructType
 ]>;
 
 def BIR_ConstantOp : BIR_Op<"constant", [

--- a/lib/BIR/IR/BIRAttrs.cpp
+++ b/lib/BIR/IR/BIRAttrs.cpp
@@ -68,5 +68,47 @@ void StringAttr::print(mlir::AsmPrinter &p) const {
   p << ">";
 }
 
+mlir::Attribute StructAttr::parse(mlir::AsmParser &p, mlir::Type attrType) {
+  if (p.parseLess().failed())
+    return {};
+
+  llvm::SmallVector<mlir::Attribute> members;
+  llvm::SmallVector<mlir::Type> memberTypes;
+
+  auto result =
+      p.parseCommaSeparatedList(mlir::AsmParser::Delimiter::Braces, [&]() {
+        mlir::Attribute member;
+        if (p.parseAttribute(member).failed())
+          return mlir::failure();
+
+        auto typedMember = llvm::dyn_cast<mlir::TypedAttr>(member);
+        if (!typedMember)
+          return mlir::failure();
+
+        members.push_back(member);
+        memberTypes.push_back(typedMember.getType());
+        return mlir::success();
+      });
+
+  if (result.failed())
+    return {};
+
+  if (p.parseGreater().failed())
+    return {};
+
+  return StructAttr::get(p.getContext(), attrType, members, memberTypes);
+}
+
+void StructAttr::print(mlir::AsmPrinter &p) const {
+  p << "<{";
+  llvm::interleaveComma(llvm::seq<size_t>(0, getMembers().size()), p,
+                        [&](size_t i) {
+                          p.printAttributeWithoutType(getMembers()[i]);
+                          p << " : ";
+                          p.printType(getMemberTypes()[i]);
+                        });
+  p << "}>";
+}
+
 } // namespace bir
 } // namespace belalang

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -42,6 +42,10 @@ LogicalResult ConstantOp::verify() {
     return success();
   }
 
+  if (isa<bir::StructType>(ty) && isa<bir::StructAttr>(attr)) {
+    return success();
+  }
+
   return emitOpError() << "type and attribute mismatch.";
 }
 

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -20,6 +20,40 @@ namespace {
 using namespace mlir;
 using namespace belalang;
 
+std::optional<mlir::Attribute>
+buildStructConstant(const mlir::TypeConverter &typeConverter,
+                    mlir::MLIRContext *ctx, bir::StructAttr structAttr) {
+  llvm::SmallVector<mlir::Attribute> members;
+  for (auto [memberAttr, memberType] :
+       llvm::zip(structAttr.getMembers(), structAttr.getMemberTypes())) {
+    if (auto intAttr = llvm::dyn_cast<bir::IntegerAttr>(memberAttr)) {
+      auto llvmTy = typeConverter.convertType(memberType);
+      if (!llvmTy)
+        return std::nullopt;
+      members.push_back(mlir::IntegerAttr::get(llvmTy, intAttr.getValue()));
+    } else if (auto floatAttr = llvm::dyn_cast<bir::FloatAttr>(memberAttr)) {
+      auto llvmTy = typeConverter.convertType(memberType);
+      if (!llvmTy)
+        return std::nullopt;
+      members.push_back(mlir::FloatAttr::get(llvmTy, floatAttr.getValue()));
+    } else if (auto boolAttr = llvm::dyn_cast<bir::BoolAttr>(memberAttr)) {
+      auto llvmTy = typeConverter.convertType(memberType);
+      if (!llvmTy)
+        return std::nullopt;
+      members.push_back(mlir::IntegerAttr::get(
+          llvmTy, static_cast<int64_t>(boolAttr.getValue())));
+    } else if (auto nested = llvm::dyn_cast<bir::StructAttr>(memberAttr)) {
+      auto nestedValue = buildStructConstant(typeConverter, ctx, nested);
+      if (!nestedValue)
+        return std::nullopt;
+      members.push_back(*nestedValue);
+    } else {
+      return std::nullopt;
+    }
+  }
+  return mlir::ArrayAttr::get(ctx, members);
+}
+
 struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
   using OpConversionPattern<bir::ConstantOp>::OpConversionPattern;
 
@@ -64,6 +98,38 @@ struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
       auto c1 = LLVM::InsertValueOp::create(rewriter, op.getLoc(), container.getType(), container, addrOfOp, rewriter.getDenseI64ArrayAttr({0}));
       rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(op, c1.getType(), c1, len, rewriter.getDenseI64ArrayAttr({1}));
 
+      return success();
+    } else if (auto structAttr = llvm::dyn_cast<bir::StructAttr>(value)) {
+      auto module = op->getParentOfType<mlir::ModuleOp>();
+      auto ctx = op->getContext();
+
+      llvm::hash_code hash = llvm::hash_combine(
+          structAttr.getMembers().size(), structAttr.getMemberTypes().size());
+      for (auto member : structAttr.getMembers())
+        hash = llvm::hash_combine(hash, member);
+      for (auto memberType : structAttr.getMemberTypes())
+        hash = llvm::hash_combine(hash, memberType);
+      std::string globalName =
+          "struct." + std::to_string(static_cast<size_t>(hash));
+
+      LLVM::GlobalOp global;
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(module.getBody());
+
+        global = module.lookupSymbol<LLVM::GlobalOp>(globalName);
+        if (!global) {
+          auto init = buildStructConstant(*getTypeConverter(), ctx, structAttr);
+          if (!init)
+            return failure();
+          global =
+              LLVM::GlobalOp::create(rewriter, op.getLoc(), type, true,
+                                     LLVM::Linkage::Private, globalName, *init);
+        }
+      }
+
+      auto addrOfOp = LLVM::AddressOfOp::create(rewriter, op.getLoc(), global);
+      rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, type, addrOfOp);
       return success();
     } else if (auto fnAttr = llvm::dyn_cast<bir::FnAttr>(value)) {
       FlatSymbolRefAttr attr = fnAttr.getValue();

--- a/tests/BIR/IR/constant-op.mlir
+++ b/tests/BIR/IR/constant-op.mlir
@@ -62,6 +62,22 @@ bir.func @main() -> !bir.int {
 
 // -----
 
+bir.func @structstruct() {
+  // CHECK: bir.constant #bir.struct<{#bir.int<42> : !bir.int, #bir.int<41> : !bir.int}> : !struct_Point
+  %0 = bir.constant #bir.struct<{#bir.int<42> : !bir.int, #bir.int<41> : !bir.int}> : !bir.struct<"Point", {!bir.int, !bir.int}>
+  bir.return
+}
+
+// -----
+
+bir.func @structint() {
+  // expected-error@+1 {{'bir.constant' op type and attribute mismatch}}
+  %0 = bir.constant #bir.struct<{#bir.int<42> : !bir.int}> : !bir.int
+  bir.return
+}
+
+// -----
+
 bir.func @boolbool() {
   // CHECK: bir.constant #bir.bool<true> : !bir.bool
   %0 = bir.constant #bir.bool<true> : !bir.bool

--- a/tests/BIR/Transforms/BIRToLLVM/struct-attr.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/struct-attr.mlir
@@ -1,0 +1,27 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+// CHECK: llvm.mlir.global private constant @struct.[[H:.*]]([42, 41]) {addr_space = 0 : i32} : !llvm.struct<"Point", (i64, i64)>
+
+// CHECK-LABEL: llvm.func @f() -> !llvm.struct<"Point", (i64, i64)>
+// CHECK: %[[C0:.*]] = llvm.mlir.addressof @struct.[[H]] : !llvm.ptr
+// CHECK: %[[C1:.*]] = llvm.load %[[C0]] : !llvm.ptr -> !llvm.struct<"Point", (i64, i64)>
+// CHECK: llvm.return %[[C1]] : !llvm.struct<"Point", (i64, i64)>
+
+bir.func @f() -> !bir.struct<"Point", {!bir.int, !bir.int}> {
+  %0 = bir.constant #bir.struct<{#bir.int<42> : !bir.int, #bir.int<41> : !bir.int}> : !bir.struct<"Point", {!bir.int, !bir.int}>
+  bir.return %0 : !bir.struct<"Point", {!bir.int, !bir.int}>
+}
+
+// -----
+
+// CHECK: llvm.mlir.global private constant @struct.[[H:.*]]([]) {addr_space = 0 : i32} : !llvm.struct<"Empty", ()>
+
+// CHECK-LABEL: llvm.func @f() -> !llvm.struct<"Empty", ()>
+// CHECK: %[[C0:.*]] = llvm.mlir.addressof @struct.[[H]] : !llvm.ptr
+// CHECK: %[[C1:.*]] = llvm.load %[[C0]] : !llvm.ptr -> !llvm.struct<"Empty", ()>
+// CHECK: llvm.return %[[C1]] : !llvm.struct<"Empty", ()>
+
+bir.func @f() -> !bir.struct<"Empty", {}> {
+  %0 = bir.constant #bir.struct<{}> : !bir.struct<"Empty", {}>
+  bir.return %0 : !bir.struct<"Empty", {}>
+}


### PR DESCRIPTION
The `bir.struct` attribute works similarly to the `bir.string` attribute, in which it gets lowered to a global variable in LLVM.