### PR TITLE
[bir][brt] Add bir.safepoint operation and LLVM StackMap support

### DIFF
--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -217,7 +217,7 @@ int build(muopt::Parser &parser) {
     const char *cc = std::getenv("CC");
     std::string cc_cmd = cc ? cc : "cc";
 
-    std::string linkCmd = cc_cmd + " " + objFile + " -L" + brt_path +
+    std::string linkCmd = cc_cmd + " -no-pie " + objFile + " -L" + brt_path +
                           " -lbrt -lbdwgc -o " + exeFile;
     if (std::system(linkCmd.c_str()) != 0) {
       std::cerr << "error: linking failed\n";

--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -218,7 +218,10 @@ int build(muopt::Parser &parser) {
     std::string cc_cmd = cc ? cc : "cc";
 
     std::string linkCmd = cc_cmd + " -no-pie " + objFile + " -L" + brt_path +
-                          " -lbrt -lbdwgc -o " + exeFile;
+                          " -Wl,-T," + brt_path +
+                          "/llvm_stackmaps.ld"
+                          " -lbrt -lbdwgc -o " +
+                          exeFile;
     if (std::system(linkCmd.c_str()) != 0) {
       std::cerr << "error: linking failed\n";
       if (std::error_code ec = llvm::sys::fs::remove(objFile))

--- a/bin/belalang/CmdRun.cpp
+++ b/bin/belalang/CmdRun.cpp
@@ -59,7 +59,10 @@ int run(muopt::Parser &parser) {
   std::string cc_cmd = cc ? cc : "cc";
 
   std::string linkCmd = cc_cmd + " -no-pie " + objFile + " -L" + brt_path +
-                        " -lbrt -lbdwgc -o " + exeFile;
+                        " -Wl,-T," + brt_path +
+                        "/llvm_stackmaps.ld"
+                        " -lbrt -lbdwgc -o " +
+                        exeFile;
   if (std::system(linkCmd.c_str()) != 0) {
     std::cerr << "error: linking failed\n";
     std::remove(objFile.c_str());

--- a/bin/belalang/CmdRun.cpp
+++ b/bin/belalang/CmdRun.cpp
@@ -54,11 +54,12 @@ int run(muopt::Parser &parser) {
   
   const char *brt_dir = std::getenv("BRT_DIR");
   std::string brt_path = brt_dir ? brt_dir : "/usr/local/lib";
-  
+
   const char *cc = std::getenv("CC");
   std::string cc_cmd = cc ? cc : "cc";
 
-  std::string linkCmd = cc_cmd + " " + objFile + " -L" + brt_path + " -lbrt -lbdwgc -o " + exeFile;
+  std::string linkCmd = cc_cmd + " -no-pie " + objFile + " -L" + brt_path +
+                        " -lbrt -lbdwgc -o " + exeFile;
   if (std::system(linkCmd.c_str()) != 0) {
     std::cerr << "error: linking failed\n";
     std::remove(objFile.c_str());

--- a/brt/BUILD.bazel
+++ b/brt/BUILD.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "brt",
-    srcs = ["src/brt.c"],
+    srcs = glob(["src/**/*.c", "src/**/*.h"]),
     linkstatic = True,
     deps = [
         "@bdwgc//:bdwgc",
@@ -16,5 +16,13 @@ genrule(
     srcs = ["@bdwgc//:bdwgc"],
     outs = ["libbdwgc.a"],
     cmd = "cp $(location @bdwgc//:bdwgc) $(RULEDIR)/libbdwgc.a",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "llvm_stackmaps_ld",
+    srcs = ["src/llvm_stackmaps.ld"],
+    outs = ["llvm_stackmaps.ld"],
+    cmd = "cp $(location src/llvm_stackmaps.ld) $@",
     visibility = ["//visibility:public"],
 )

--- a/brt/src/brt.c
+++ b/brt/src/brt.c
@@ -1,3 +1,5 @@
+#include "llvm_stackmap.h"
+
 #include <gc.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -20,5 +22,8 @@ void brt_print_string(struct BrString v) {
   }
 }
 
-void brt_init() { GC_init(); }
+void brt_init() {
+  (void)get_llvm_stkmap_section();
+  GC_init();
+}
 void *brt_gc_alloc(size_t size) { return GC_malloc(size); }

--- a/brt/src/llvm_stackmap.c
+++ b/brt/src/llvm_stackmap.c
@@ -1,0 +1,18 @@
+#include "llvm_stackmap.h"
+
+extern const uint8_t __start_llvm_stackmaps[];
+extern const uint8_t __stop_llvm_stackmaps[];
+
+struct LLVMStkMapSection get_llvm_stkmap_section() {
+  uintptr_t start = (uintptr_t)__start_llvm_stackmaps;
+  uintptr_t stop = (uintptr_t)__stop_llvm_stackmaps;
+
+  if (stop < start)
+    return (struct LLVMStkMapSection){.start = NULL, .size = 0};
+
+  struct LLVMStkMapSection s = {
+      .start = (const uint8_t *)start,
+      .size = (size_t)(stop - start),
+  };
+  return s;
+}

--- a/brt/src/llvm_stackmap.h
+++ b/brt/src/llvm_stackmap.h
@@ -1,0 +1,60 @@
+#ifndef BRT_LLVM_STACKMAP_H_
+#define BRT_LLVM_STACKMAP_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct LLVMStkMapHeader {
+  uint8_t version;
+  uint8_t reserved0;
+  uint16_t reserved1;
+  uint32_t num_functions;
+  uint32_t num_constants;
+  uint32_t num_records;
+} __attribute__((packed));
+
+struct LLVMStkMapSizeRecord {
+  uint64_t function_address;
+  uint64_t stack_size;
+  uint64_t record_count;
+} __attribute__((packed));
+
+struct LLVMStkMapConstant {
+  uint64_t large_constant;
+} __attribute__((packed));
+
+struct LLVMStkMapLocation {
+  uint8_t kind;
+  uint8_t reserved0;
+  uint16_t location_size;
+  uint16_t dwarf_regnum;
+  uint16_t reserved1;
+  int32_t offset_or_small_constant;
+} __attribute__((packed));
+
+struct LLVMStkMapRecordHeader {
+  uint64_t patch_point_id;
+  uint32_t instruction_offset;
+  uint16_t reserved;
+  uint16_t num_locations;
+} __attribute__((packed));
+
+struct LLVMStkMapLiveOutsHeader {
+  uint16_t padding;
+  uint16_t num_live_outs;
+} __attribute__((packed));
+
+struct LLVMStkMapLiveOut {
+  uint16_t dwarf_regnum;
+  uint8_t reserved;
+  uint8_t size_in_bytes;
+} __attribute__((packed));
+
+struct LLVMStkMapSection {
+  const uint8_t *start;
+  size_t size;
+};
+
+struct LLVMStkMapSection get_llvm_stkmap_section();
+
+#endif // BRT_LLVM_STACKMAP_H_

--- a/brt/src/llvm_stackmaps.ld
+++ b/brt/src/llvm_stackmaps.ld
@@ -1,0 +1,8 @@
+SECTIONS {
+  .llvm_stackmaps : ALIGN(8) {
+    __start_llvm_stackmaps = .;
+    KEEP(*(.llvm_stackmaps))
+    __stop_llvm_stackmaps = .;
+  }
+}
+INSERT AFTER .rodata;

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -537,4 +537,15 @@ def BIR_AllocHeapOp : BIR_Op<"alloc_heap"> {
   }];
 }
 
+def BIR_SafepointOp : BIR_Op<"safepoint"> {
+  let arguments = (ins
+    I64Attr:$id,
+    Variadic<BIR_RefType>:$roots
+  );
+
+  let assemblyFormat = [{
+    $id (`(` $roots^ `:` type($roots) `)`)? attr-dict
+  }];
+}
+
 #endif // BELALANG_IR_OPS_TD_

--- a/include/belalang/BIR/Passes.td
+++ b/include/belalang/BIR/Passes.td
@@ -24,6 +24,11 @@ def BelalangLowerDeclToMemoryPass : Pass<"bir-lower-decl-to-memory"> {
   let dependentDialects = ["::belalang::bir::BIRDialect"];
 }
 
+def BelalangInsertStackMapsPass : Pass<"bir-insert-stackmaps"> {
+  let summary = "insert stackmap safepoints at GC allocation sites";
+  let dependentDialects = ["::belalang::bir::BIRDialect"];
+}
+
 def BelalangBIRToLLVMPass : Pass<"convert-bir-to-llvm"> {
   let summary = "lower bir instructions to LLVM";
   let dependentDialects = ["::belalang::bir::BIRDialect",

--- a/lib/BIR/Pipelines.cpp
+++ b/lib/BIR/Pipelines.cpp
@@ -13,6 +13,7 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangLowerToRuntimeCallsPass());
   pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
+  pm.addPass(createBelalangInsertStackMapsPass());
 }
 
 void registerBIRPipelines() {

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -742,6 +742,48 @@ static void insertBRTInitCall(mlir::Operation *op) {
       builder.getI32ArrayAttr(prios), builder.getArrayAttr(datals));
 }
 
+struct SafepointOpLowering final
+    : public OpConversionPattern<bir::SafepointOp> {
+  using OpConversionPattern<bir::SafepointOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::SafepointOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ctx = op.getContext();
+
+    auto i64Ty = mlir::IntegerType::get(ctx, 64);
+    auto i32Ty = mlir::IntegerType::get(ctx, 32);
+
+    // declare void
+    //   @llvm.experimental.stackmap(i64 <id>, i32 <numShadowBytes>, ...)
+
+    llvm::SmallVector<mlir::Value> args;
+
+    // Insert the i64 id argument.
+    args.push_back(
+        LLVM::ConstantOp::create(
+            rewriter, loc, i64Ty,
+            rewriter.getI64IntegerAttr(static_cast<int64_t>(op.getId())))
+            .getResult());
+
+    // Insert the i32 numShadowBytes argument.
+    args.push_back(LLVM::ConstantOp::create(rewriter, loc, i32Ty,
+                                            rewriter.getI32IntegerAttr(0))
+                       .getResult());
+
+    // Insert the pointers arguments.
+    for (auto root : adaptor.getRoots())
+      args.push_back(root);
+
+    LLVM::CallIntrinsicOp::create(
+        rewriter, loc, rewriter.getStringAttr("llvm.experimental.stackmap"),
+        args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 } // namespace
 
 void belalang::bir::populateBelalangBIRToLLVMPatterns(
@@ -752,8 +794,8 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
                ShrOpLowering, AllocHeapOpLowering, StoreOpLowering,
                VarLoadOpLowering, CondBrLowering, CmpOpLowering,
-               GetMemberOpLowering>(
-      typeConverter, patterns.getContext());
+               GetMemberOpLowering, SafepointOpLowering>(typeConverter,
+                                                         patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/BIR/Transforms/InsertStackMaps.cpp
+++ b/lib/BIR/Transforms/InsertStackMaps.cpp
@@ -1,0 +1,63 @@
+#include "belalang/BIR/IR/BIR.h"
+#include "belalang/BIR/Passes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_BELALANGINSERTSTACKMAPSPASS
+#include "belalang/BIR/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+using namespace mlir;
+using namespace belalang;
+using namespace belalang::bir;
+
+struct BelalangInsertStackMapsPass
+    : public impl::BelalangInsertStackMapsPassBase<
+          BelalangInsertStackMapsPass> {
+  using impl::BelalangInsertStackMapsPassBase<
+      BelalangInsertStackMapsPass>::BelalangInsertStackMapsPassBase;
+
+  void runOnOperation() override {
+    uint64_t nextId = 0;
+
+    getOperation()->walk([&](bir::FuncOp func) {
+      mlir::DominanceInfo dom(func);
+
+      llvm::SmallVector<mlir::Value> refValues;
+      func.walk([&](mlir::Operation *op) {
+        for (auto res : op->getResults()) {
+          if (mlir::isa<bir::RefType>(res.getType()))
+            refValues.push_back(res);
+        }
+      });
+      for (auto &block : func.getBody().getBlocks()) {
+        for (auto arg : block.getArguments()) {
+          if (mlir::isa<bir::RefType>(arg.getType()))
+            refValues.push_back(arg);
+        }
+      }
+
+      llvm::SmallVector<bir::AllocHeapOp> allocs;
+      func.walk([&](bir::AllocHeapOp alloc) { allocs.push_back(alloc); });
+
+      for (auto alloc : allocs) {
+        llvm::SmallVector<mlir::Value> roots;
+        for (auto v : refValues) {
+          if (dom.properlyDominates(v, alloc))
+            roots.push_back(v);
+        }
+
+        mlir::OpBuilder builder(alloc);
+        bir::SafepointOp::create(builder, alloc.getLoc(), nextId++, roots);
+      }
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> belalang::bir::createBelalangInsertStackMapsPass() {
+  return std::make_unique<BelalangInsertStackMapsPass>();
+}

--- a/tests/BIR/Target/LLVMIR/string.mlir
+++ b/tests/BIR/Target/LLVMIR/string.mlir
@@ -9,6 +9,7 @@
 // CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
 // CHECK-LABEL:define %bel.String @main() {
+// CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
 // CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
 // CHECK-NEXT:   store %bel.String { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load %bel.String, ptr %[[C1]], align 8
@@ -36,6 +37,7 @@ bir.func @main() -> !bir.string {
 // CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
 // CHECK-LABEL:define void @main() {
+// CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
 // CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
 // CHECK-NEXT:   store %bel.String { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load %bel.String, ptr %[[C1]], align 8

--- a/tests/BIR/Transforms/InsertStackMaps/BUILD.bazel
+++ b/tests/BIR/Transforms/InsertStackMaps/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
+++ b/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
@@ -1,0 +1,83 @@
+// RUN: %bir-opt --split-input-file --bir-insert-stackmaps %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @alloc_straight_line
+// CHECK:        %0 = bir.constant #bir.int<1> : !bir.int
+// CHECK-NEXT:   bir.safepoint 0
+// CHECK-NEXT:   %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+// CHECK-NEXT:   %2 = bir.constant #bir.float<1.000000e+00> : !bir.float
+// CHECK-NEXT:   bir.safepoint 1(%1 : !bir.ref<!bir.int>)
+// CHECK-NEXT:   %3 = bir.alloc_heap 8 : !bir.ref<!bir.float>
+// CHECK-NEXT:   bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
+// CHECK-NEXT:   %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK-NEXT:   %5 = bir.constant #bir.int<1> : !bir.int
+// CHECK-NEXT:   %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
+// CHECK-NEXT:   bir.safepoint 2(%1, %3 : !bir.ref<!bir.int>, !bir.ref<!bir.float>)
+// CHECK-NEXT:   %7 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
+// CHECK-NEXT:   %8 = bir.load %7 : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK-NEXT:   bir.return %8 : !bir.int
+// CHECK-NEXT: }
+
+bir.func @alloc_straight_line() -> !bir.int {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.constant #bir.float<1.000000e+00> : !bir.float
+  %3 = bir.alloc_heap 8 : !bir.ref<!bir.float>
+  bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
+  %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+  %5 = bir.constant #bir.int<1> : !bir.int
+  %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
+  %7 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
+  %8 = bir.load %7 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.return %8 : !bir.int
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @alloc_cross_block
+// CHECK:        %0 = bir.constant #bir.int<0> : !bir.int
+// CHECK-NEXT:   bir.safepoint 0
+// CHECK-NEXT:   %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+// CHECK-NEXT:   cf.br ^bb1
+// CHECK-NEXT: ^bb1:  // pred: ^bb0
+// CHECK-NEXT:   %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK-NEXT:   %3 = bir.constant #bir.int<1> : !bir.int
+// CHECK-NEXT:   %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
+// CHECK-NEXT:   bir.safepoint 1(%1 : !bir.ref<!bir.int>)
+// CHECK-NEXT:   %5 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
+// CHECK-NEXT:   %6 = bir.load %5 : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK-NEXT:   bir.return %6 : !bir.int
+// CHECK-NEXT: }
+
+bir.func @alloc_cross_block() -> !bir.int {
+  %0 = bir.constant #bir.int<0> : !bir.int
+  %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+  cf.br ^bb1
+^bb1:
+  %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+  %3 = bir.constant #bir.int<1> : !bir.int
+  %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
+  %5 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
+  %6 = bir.load %5 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.return %6 : !bir.int
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @no_alloc
+// CHECK:        %0 = bir.constant #bir.int<42> : !bir.int
+// CHECK-NEXT:   bir.return %0 : !bir.int
+// CHECK-NEXT: }
+// CHECK-NOT: bir.safepoint
+
+bir.func @no_alloc() -> !bir.int {
+  %0 = bir.constant #bir.int<42> : !bir.int
+  bir.return %0 : !bir.int
+}

--- a/tests/LLVMGen/functions.bel
+++ b/tests/LLVMGen/functions.bel
@@ -5,8 +5,10 @@
 
 # CHECK-LABEL:define i64 @fn.main.anon(
 # CHECK-SAME:     i64 %[[ARG0:.*]], i64 %[[ARG1:.*]]) {
+# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
 # CHECK-NEXT:   %[[V0:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store i64 %[[ARG0]], ptr %[[V0]], align 4
+# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V0]])
 # CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store i64 %[[ARG1]], ptr %[[V1]], align 4
 # CHECK-NEXT:   %[[V2:.*]] = load i64, ptr %[[V0]], align 4
@@ -16,16 +18,20 @@
 # CHECK-NEXT: }
 
 # CHECK-LABEL:define i64 @main() {
+# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
 # CHECK-NEXT:   %[[V5:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store ptr @fn.main.anon, ptr %[[V5]], align 8
 # CHECK-NEXT:   %[[V6:.*]] = load ptr, ptr %[[V5]], align 8
 # CHECK-NEXT:   %[[V7:.*]] = call i64 %[[V6]](i64 2, i64 3)
+# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V5]])
 # CHECK-NEXT:   %[[V8:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store i64 %[[V7]], ptr %[[V8]], align 4
 # CHECK-NEXT:   %[[V9:.*]] = load i64, ptr %[[V8]], align 4
 # CHECK-NEXT:   call void @brt_print_int(i64 %[[V9]])
 # CHECK-NEXT:   ret i64 0
 # CHECK-NEXT: }
+
+# CHECK: declare void @llvm.experimental.stackmap(i64 immarg, i32 immarg, ...)
 
 add := fn(x: Int, y: Int): Int { return x + y }
 p := add(2, 3)

--- a/tests/LLVMGen/stackmap.bel
+++ b/tests/LLVMGen/stackmap.bel
@@ -1,0 +1,15 @@
+# RUN: %belalang build --emit=llvm %s | %FileCheck %s
+
+# CHECK-LABEL:define i64 @main() {
+# CHECK:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
+# CHECK-NEXT:   %[[V0:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V0]])
+# CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK:   ret i64 0
+# CHECK-NEXT: }
+
+# CHECK: declare void @llvm.experimental.stackmap(i64 immarg, i32 immarg, ...)
+
+x := 1
+y := x + 1
+print(y)


### PR DESCRIPTION
The current safepoint system uses LLVM's stackmap infrastructure. Though, this structure is limited in which it requires `-no-pie`. In the future, it is hoped that LLVM's stackmap supports PIE code or we move to a different, maybe self-built stackmap infrastructure.

I couldn't get the section working, so to compensate, a linker script was used.