### PR TITLE
[bir] Implement AllocStackOp and its LLVM lowering

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -537,6 +537,18 @@ def BIR_AllocHeapOp : BIR_Op<"alloc_heap"> {
   }];
 }
 
+def BIR_AllocStackOp : BIR_Op<"alloc_stack"> {
+  let arguments = (ins);
+
+  let results = (outs
+    BIR_RefType:$result
+  );
+
+  let assemblyFormat = [{
+    `:` qualified(type($result)) attr-dict
+  }];
+}
+
 def BIR_SafepointOp : BIR_Op<"safepoint"> {
   let arguments = (ins
     I64Attr:$id,

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -510,6 +510,30 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
   };
 };
 
+struct AllocStackOpLowering final
+    : public OpConversionPattern<bir::AllocStackOp> {
+  using OpConversionPattern<bir::AllocStackOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::AllocStackOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ctx = op.getContext();
+    auto loc = op.getLoc();
+
+    mlir::Type resultTy = LLVM::LLVMPointerType::get(ctx);
+    mlir::Type elementTy =
+        getTypeConverter()->convertType(op.getType().getReferent());
+
+    // Currently limit the possible allocation size to one element.
+    auto i64ty = rewriter.getI64Type();
+    mlir::Value arraySize = LLVM::ConstantOp::create(rewriter, loc, i64ty, 1);
+
+    rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(op, resultTy, elementTy,
+                                                arraySize);
+    return success();
+  };
+};
+
 struct StoreOpLowering final : public OpConversionPattern<bir::StoreOp> {
   using OpConversionPattern<bir::StoreOp>::OpConversionPattern;
 
@@ -792,10 +816,10 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                CallIndirectOpLowering, ReturnOpLowering, AddOpLowering,
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
-               ShrOpLowering, AllocHeapOpLowering, StoreOpLowering,
-               VarLoadOpLowering, CondBrLowering, CmpOpLowering,
-               GetMemberOpLowering, SafepointOpLowering>(typeConverter,
-                                                         patterns.getContext());
+               ShrOpLowering, AllocHeapOpLowering, AllocStackOpLowering,
+               StoreOpLowering, VarLoadOpLowering, CondBrLowering,
+               CmpOpLowering, GetMemberOpLowering, SafepointOpLowering>(
+      typeConverter, patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/BIR/IR/alloc-stack-op.mlir
+++ b/tests/BIR/IR/alloc-stack-op.mlir
@@ -1,0 +1,8 @@
+// RUN: %bir-opt --split-input-file --verify-roundtrip %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @basic
+bir.func @basic() {
+  // CHECK: %[[C1:.*]] = bir.alloc_stack : !bir.ref<!bir.int>
+  %1 = bir.alloc_stack : !bir.ref<!bir.int>
+  bir.return
+}

--- a/tests/BIR/Transforms/BIRToLLVM/alloc-stack-op.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/alloc-stack-op.mlir
@@ -1,0 +1,19 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+// CHECK-LABEL: llvm.func @alloc_stack_int
+bir.func @alloc_stack_int() {
+  // CHECK:      %[[C0:.*]] = llvm.mlir.constant(1 : i64) : i64
+  // CHECK-NEXT: %[[C1:.*]] = llvm.alloca %[[C0]] x i64 : (i64) -> !llvm.ptr
+  %1 = bir.alloc_stack : !bir.ref<!bir.int>
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @alloc_stack_struct
+bir.func @alloc_stack_struct() {
+  // CHECK:      %[[C0:.*]] = llvm.mlir.constant(1 : i64) : i64
+  // CHECK-NEXT: %[[C1:.*]] = llvm.alloca %[[C0]] x !llvm.struct<"T", (i64, i64)> : (i64) -> !llvm.ptr
+  %1 = bir.alloc_stack : !bir.ref<!bir.struct<"T", {!bir.int, !bir.int}>>
+  bir.return
+}


### PR DESCRIPTION
Closes #332 

This change adds the `bir.alloc_stack` op and its LLVM lowering. Its design is mostly semantically similar to LLVM alloca. Currently, we limit the size of the allocation to only one. Maybe in the future, we can make it more than one.

Relevant issues: #333, #335