### PR TITLE
[bir] Make AllocHeapOp only take type and not type size

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -524,16 +524,14 @@ def BIR_GetMemberOp : BIR_Op<"get_member"> {
 }
 
 def BIR_AllocHeapOp : BIR_Op<"alloc_heap"> {
-  let arguments = (ins 
-    I64Attr:$size
-  );
+  let arguments = (ins);
 
   let results = (outs
     BIR_RefType:$result
   );
 
   let assemblyFormat = [{
-    $size `:` qualified(type($result)) attr-dict
+    `:` qualified(type($result)) attr-dict
   }];
 }
 

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -484,9 +484,15 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
   LogicalResult
   matchAndRewrite(bir::AllocHeapOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto elSize = op.getSize();
     auto loc = op.getLoc();
     auto ctx = op.getContext();
+    auto dataLayout = mlir::DataLayout::closest(op);
+
+    // The AllocHeapOp strictly uses the RefType as the result type.
+    // We're allocating memory the size of the referent.
+    auto type = mlir::cast<bir::RefType>(op.getType());
+    auto referentLLVMTy = getTypeConverter()->convertType(type.getReferent());
+    uint64_t typeSize = dataLayout.getTypeSize(referentLLVMTy);
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
     if (!module.lookupSymbol(kGCAlloc)) {
@@ -498,12 +504,13 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
     }
 
     auto i64Type = mlir::IntegerType::get(ctx, 64);
-    auto sizeVal =
-        LLVM::ConstantOp::create(rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elSize));
+    auto sizeVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(typeSize));
 
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
     auto calleeAttr = FlatSymbolRefAttr::get(ctx, kGCAlloc);
-    auto allocCall = LLVM::CallOp::create(rewriter, loc, ptrType, calleeAttr, sizeVal.getResult());
+    auto allocCall = LLVM::CallOp::create(rewriter, loc, ptrType, calleeAttr,
+                                          sizeVal.getResult());
 
     rewriter.replaceOp(op, allocCall.getResult());
     return success();

--- a/lib/BIR/Transforms/LowerDeclToMemory.cpp
+++ b/lib/BIR/Transforms/LowerDeclToMemory.cpp
@@ -19,24 +19,7 @@ struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
   matchAndRewrite(bir::DeclareOp op,
                   mlir::PatternRewriter &rewriter) const override {
     auto refType = mlir::cast<bir::RefType>(op.getType());
-    auto referentTy = refType.getReferent();
-
-    int64_t elSize;
-    if (mlir::isa<bir::IntType>(referentTy))
-      elSize = 8;
-    else if (mlir::isa<bir::FloatType>(referentTy))
-      elSize = 8;
-    else if (mlir::isa<bir::StringType>(referentTy))
-      elSize = 16;
-    else if (mlir::isa<bir::BoolType>(referentTy))
-      elSize = 8;
-    else if (mlir::isa<mlir::FunctionType>(referentTy))
-      elSize = 8;
-    else
-      return failure();
-
-    mlir::Type ty = op.getResult().getType();
-    rewriter.replaceOpWithNewOp<bir::AllocHeapOp>(op, ty, elSize);
+    rewriter.replaceOpWithNewOp<bir::AllocHeapOp>(op, refType);
     return success();
   };
 };

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -68,7 +68,7 @@ bir.func @main() -> !bir.int {
 // CHECK: llvm.return %[[LOAD]] : i64
 
 bir.func @main() -> !bir.int {
-  %0 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  %0 = bir.alloc_heap : !bir.ref<!bir.int>
   %1 = bir.constant #bir.int<12> : !bir.int
   bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
   %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int

--- a/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
+++ b/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
@@ -3,17 +3,17 @@
 // CHECK-LABEL: bir.func @alloc_straight_line
 // CHECK:        %0 = bir.constant #bir.int<1> : !bir.int
 // CHECK-NEXT:   bir.safepoint 0
-// CHECK-NEXT:   %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   %1 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
 // CHECK-NEXT:   %2 = bir.constant #bir.float<1.000000e+00> : !bir.float
 // CHECK-NEXT:   bir.safepoint 1(%1 : !bir.ref<!bir.int>)
-// CHECK-NEXT:   %3 = bir.alloc_heap 8 : !bir.ref<!bir.float>
+// CHECK-NEXT:   %3 = bir.alloc_heap : !bir.ref<!bir.float>
 // CHECK-NEXT:   bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
 // CHECK-NEXT:   %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:   %5 = bir.constant #bir.int<1> : !bir.int
 // CHECK-NEXT:   %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
 // CHECK-NEXT:   bir.safepoint 2(%1, %3 : !bir.ref<!bir.int>, !bir.ref<!bir.float>)
-// CHECK-NEXT:   %7 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   %7 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
 // CHECK-NEXT:   %8 = bir.load %7 : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:   bir.return %8 : !bir.int
@@ -21,15 +21,15 @@
 
 bir.func @alloc_straight_line() -> !bir.int {
   %0 = bir.constant #bir.int<1> : !bir.int
-  %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  %1 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
   %2 = bir.constant #bir.float<1.000000e+00> : !bir.float
-  %3 = bir.alloc_heap 8 : !bir.ref<!bir.float>
+  %3 = bir.alloc_heap : !bir.ref<!bir.float>
   bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
   %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
   %5 = bir.constant #bir.int<1> : !bir.int
   %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
-  %7 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  %7 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
   %8 = bir.load %7 : (!bir.ref<!bir.int>) -> !bir.int
   bir.return %8 : !bir.int
@@ -40,7 +40,7 @@ bir.func @alloc_straight_line() -> !bir.int {
 // CHECK-LABEL: bir.func @alloc_cross_block
 // CHECK:        %0 = bir.constant #bir.int<0> : !bir.int
 // CHECK-NEXT:   bir.safepoint 0
-// CHECK-NEXT:   %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   %1 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
 // CHECK-NEXT:   cf.br ^bb1
 // CHECK-NEXT: ^bb1:  // pred: ^bb0
@@ -48,7 +48,7 @@ bir.func @alloc_straight_line() -> !bir.int {
 // CHECK-NEXT:   %3 = bir.constant #bir.int<1> : !bir.int
 // CHECK-NEXT:   %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
 // CHECK-NEXT:   bir.safepoint 1(%1 : !bir.ref<!bir.int>)
-// CHECK-NEXT:   %5 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+// CHECK-NEXT:   %5 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
 // CHECK-NEXT:   %6 = bir.load %5 : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:   bir.return %6 : !bir.int
@@ -56,14 +56,14 @@ bir.func @alloc_straight_line() -> !bir.int {
 
 bir.func @alloc_cross_block() -> !bir.int {
   %0 = bir.constant #bir.int<0> : !bir.int
-  %1 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  %1 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
   cf.br ^bb1
 ^bb1:
   %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
   %3 = bir.constant #bir.int<1> : !bir.int
   %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
-  %5 = bir.alloc_heap 8 : !bir.ref<!bir.int>
+  %5 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
   %6 = bir.load %5 : (!bir.ref<!bir.int>) -> !bir.int
   bir.return %6 : !bir.int


### PR DESCRIPTION
Closes #333

This change removes the type size argument from AllocHeapOp to closely follow AllocStackOp. Now, it uses MLIR's type converter and its DataLayout to figure out the size of a type. This way, data regarding how large a type is is not hard coded inside LowerDeclToMemory.

The issue proposed deferring all the way to LLVM IR, but I don't think its worth it. At its core, AllocHeapOp is lowered to a call to runtime function, `brt_gc_alloc`. I'm not sure on how to extend LLVM with new instructions/ops; its more of an MLIR role. Therefore, the LLVM IR only sees a call to `brt_gc_alloc` with the type size.