### PR TITLE
[chore][bazel] Modify flags used

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,12 @@
+# C options
+build --conlyopt=-std=c11
+
+# C++ options
+build --cxxopt=-std=c++17
+build --cxxopt=-fno-exceptions
+build --cxxopt=-fno-rtti
+
+# Rust options
 build --@rules_rust//rust/settings:rustfmt.toml=//:.rustfmt.toml
 build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --output_groups=+rustfmt_checks
@@ -15,10 +24,5 @@ build --@llvm//config:empty_sysroot=True
 build --@llvm//config:experimental_stub_libgcc_s=True
 
 test --test_output=errors
-
-# Workaround: Rust nightly's libstd weakly references gettid (glibc >= 2.30),
-# but the hermetic LLVM toolchain ships glibc 2.28 stubs missing this symbol.
-# --defsym stubs it at link time; Rust's dlsym fallback means it's never called.
-build --linkopt=-Wl,--defsym,gettid=0
 
 build --workspace_status_command=tools/workspace_status.sh

--- a/brt/src/gc.c
+++ b/brt/src/gc.c
@@ -1,3 +1,5 @@
+#define _DEFAULT_SOURCE
+
 #include "gc.h"
 #include "errors.h"
 #include "utils.h"


### PR DESCRIPTION
Enforces the usage of C11 and C++17. Also disables C++ RTTI and exceptions.