### PR TITLE
[bir] Initial implementation of EscapeAnalysis

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,6 @@ build --extra_toolchains=@llvm//toolchain:all
 build --@llvm//config:empty_sysroot=True
 build --@llvm//config:experimental_stub_libgcc_s=True
 
-test --test_output=errors
+test --test_output=all
 
 build --workspace_status_command=tools/workspace_status.sh

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -67,6 +67,7 @@ cc_library(
         ":BelalangBIRLoopOpInterfaceIncGen",
         ":BelalangPassIncGen",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Analysis",
     ],
 )
 

--- a/include/belalang/BIR/Analysis/EscapeAnalysis.h
+++ b/include/belalang/BIR/Analysis/EscapeAnalysis.h
@@ -1,0 +1,45 @@
+#ifndef BELALANG_BIR_ANALYSIS_ESCAPEANALYSIS_H_
+#define BELALANG_BIR_ANALYSIS_ESCAPEANALYSIS_H_
+
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+
+namespace belalang {
+namespace bir {
+
+struct EscapeLattice : mlir::dataflow::AbstractSparseLattice {
+  using AbstractSparseLattice::AbstractSparseLattice;
+
+  void print(llvm::raw_ostream &os) const override;
+
+  mlir::ChangeResult markEscapes();
+
+  mlir::ChangeResult
+  meet(const mlir::dataflow::AbstractSparseLattice &other) override;
+
+  bool escapes = false;
+};
+
+class EscapeAnalysis
+    : public mlir::dataflow::SparseBackwardDataFlowAnalysis<EscapeLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  mlir::LogicalResult
+  visitOperation(mlir::Operation *op, llvm::ArrayRef<EscapeLattice *> operands,
+                 llvm::ArrayRef<const EscapeLattice *> results) override;
+
+  void visitBranchOperand(mlir::OpOperand &operand) override;
+
+  void visitCallOperand(mlir::OpOperand &operand) override;
+
+  void visitNonControlFlowArguments(
+      mlir::RegionSuccessor &successor,
+      llvm::ArrayRef<mlir::BlockArgument> arguments) override;
+
+  void setToExitState(EscapeLattice *lattice) override;
+};
+
+} // namespace bir
+} // namespace belalang
+
+#endif // BELALANG_BIR_ANALYSIS_ESCAPEANALYSIS_H_

--- a/include/belalang/BIR/Passes.h
+++ b/include/belalang/BIR/Passes.h
@@ -7,6 +7,10 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+namespace mlir {
+class DataFlowSolver;
+} // namespace mlir
+
 namespace belalang {
 namespace bir {
 
@@ -17,7 +21,8 @@ namespace bir {
 #include "belalang/BIR/Passes.h.inc"
 
 void populateBelalangFlattenCFGPatterns(mlir::RewritePatternSet &patterns);
-void populateBelalangLowerDeclToMemoryPatterns(mlir::RewritePatternSet &patterns);
+void populateBelalangLowerDeclToMemoryPatterns(
+    mlir::RewritePatternSet &patterns, mlir::DataFlowSolver &solver);
 void populateBelalangLowerFuncExprPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangLowerToRuntimeCallsPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns,

--- a/lib/BIR/Analysis/EscapeAnalysis.cpp
+++ b/lib/BIR/Analysis/EscapeAnalysis.cpp
@@ -1,0 +1,85 @@
+#include "belalang/BIR/Analysis/EscapeAnalysis.h"
+#include "belalang/BIR/IR/BIR.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+
+namespace belalang {
+namespace bir {
+
+// -----------------------------------------------------------------------------
+// Escape Lattice
+// -----------------------------------------------------------------------------
+
+void EscapeLattice::print(llvm::raw_ostream &os) const {
+  os << (escapes ? "escape" : "noescape");
+}
+
+mlir::ChangeResult EscapeLattice::markEscapes() {
+  bool was = escapes;
+  escapes = true;
+  return was ? mlir::ChangeResult::NoChange : mlir::ChangeResult::Change;
+}
+
+mlir::ChangeResult
+EscapeLattice::meet(const mlir::dataflow::AbstractSparseLattice &other) {
+  auto lattice = reinterpret_cast<const EscapeLattice *>(&other);
+  return lattice->escapes ? markEscapes() : mlir::ChangeResult::NoChange;
+}
+
+// -----------------------------------------------------------------------------
+// Escape Analysis
+// -----------------------------------------------------------------------------
+
+mlir::LogicalResult
+EscapeAnalysis::visitOperation(mlir::Operation *op,
+                               llvm::ArrayRef<EscapeLattice *> operands,
+                               llvm::ArrayRef<const EscapeLattice *> results) {
+  if (mlir::isa<bir::ReturnOp>(op)) {
+    for (EscapeLattice *operand : operands) {
+      propagateIfChanged(operand, operand->markEscapes());
+    }
+  }
+
+  if (mlir::isa<bir::VarLoadOp>(op) && !results.empty() &&
+      results.front()->escapes) {
+    propagateIfChanged(operands.front(), operands.front()->markEscapes());
+  }
+
+  return mlir::success();
+}
+
+void EscapeAnalysis::visitBranchOperand(mlir::OpOperand &operand) {
+  mlir::Operation *op = operand.getOwner();
+  assert(isa<RegionBranchOpInterface>(op) || isa<BranchOpInterface>(op) ||
+         isa<RegionBranchTerminatorOpInterface>(op));
+
+  auto *visitOp = mlir::isa<mlir::RegionBranchTerminatorOpInterface>(op)
+                      ? op->getParentOp()
+                      : op;
+
+  EscapeLattice *operands[] = {getLatticeElement(operand.get())};
+
+  llvm::SmallVector<const EscapeLattice *, 4> results;
+  for (const mlir::Value result : visitOp->getResults())
+    results.push_back(getLatticeElement(result));
+
+  (void)visitOperation(visitOp, operands, results);
+}
+
+void EscapeAnalysis::visitCallOperand(mlir::OpOperand &operand) {
+  mlir::Operation *op = operand.getOwner();
+  assert(mlir::isa<CallOpInterface>(op));
+
+  EscapeLattice *lattice = getLatticeElement(operand.get());
+  propagateIfChanged(lattice, lattice->markEscapes());
+}
+
+void EscapeAnalysis::visitNonControlFlowArguments(
+    mlir::RegionSuccessor &successor,
+    llvm::ArrayRef<mlir::BlockArgument> arguments) {}
+
+void EscapeAnalysis::setToExitState(EscapeLattice *lattice) {
+  propagateIfChanged(lattice, lattice->markEscapes());
+}
+
+} // namespace bir
+} // namespace belalang

--- a/lib/BIR/Transforms/LowerDeclToMemory.cpp
+++ b/lib/BIR/Transforms/LowerDeclToMemory.cpp
@@ -1,5 +1,8 @@
+#include "belalang/BIR/Analysis/EscapeAnalysis.h"
 #include "belalang/BIR/IR/BIR.h"
 #include "belalang/BIR/Passes.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
@@ -13,22 +16,34 @@ using namespace belalang;
 using namespace belalang::bir;
 
 struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
-  using OpRewritePattern<bir::DeclareOp>::OpRewritePattern;
+  DeclareOpLowering(mlir::MLIRContext *ctx, mlir::DataFlowSolver &solver)
+      : OpRewritePattern<bir::DeclareOp>(ctx), solver(solver) {}
 
   LogicalResult
   matchAndRewrite(bir::DeclareOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    const auto *state = 
+        solver.lookupState<EscapeLattice>(op.getResult());
+    bool escapes = state && state->escapes;
+
     auto refType = mlir::cast<bir::RefType>(op.getType());
-    rewriter.replaceOpWithNewOp<bir::AllocHeapOp>(op, refType);
+    if (escapes)
+      rewriter.replaceOpWithNewOp<bir::AllocHeapOp>(op, refType);
+    else
+      rewriter.replaceOpWithNewOp<bir::AllocStackOp>(op, refType);
+
     return success();
   };
+
+private:
+  mlir::DataFlowSolver &solver;
 };
 
 } // namespace
 
 void belalang::bir::populateBelalangLowerDeclToMemoryPatterns(
-    mlir::RewritePatternSet &patterns) {
-  patterns.add<DeclareOpLowering>(patterns.getContext());
+    mlir::RewritePatternSet &patterns, mlir::DataFlowSolver &solver) {
+  patterns.add<DeclareOpLowering>(patterns.getContext(), solver);
 }
 
 // -----------------------------------------------------------------------------
@@ -42,8 +57,16 @@ struct BelalangLowerDeclToMemoryPass
       BelalangLowerDeclToMemoryPass>::BelalangLowerDeclToMemoryPassBase;
 
   void runOnOperation() override {
+    SymbolTableCollection symbolTable;
+
+    DataFlowSolver solver;
+    mlir::dataflow::loadBaselineAnalyses(solver);
+    solver.load<EscapeAnalysis>(symbolTable);
+    if (solver.initializeAndRun(getOperation()).failed())
+      return signalPassFailure();
+
     mlir::RewritePatternSet patterns(&getContext());
-    belalang::bir::populateBelalangLowerDeclToMemoryPatterns(patterns);
+    belalang::bir::populateBelalangLowerDeclToMemoryPatterns(patterns, solver);
 
     if (mlir::applyPatternsGreedily(getOperation(), std::move(patterns))
             .failed()) {

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
     deps = [
         "//include:BIR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:ControlFlowDialect",

--- a/tests/BIR/Transforms/LowerDeclToMemory/BUILD.bazel
+++ b/tests/BIR/Transforms/LowerDeclToMemory/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/LowerDeclToMemory/escape.mlir
+++ b/tests/BIR/Transforms/LowerDeclToMemory/escape.mlir
@@ -1,0 +1,17 @@
+// RUN: %bir-opt --split-input-file --bir-lower-decl-to-memory %s \
+// RUN: | %FileCheck %s
+
+// CHECK-LABEL: bir.func @main
+bir.func @main() -> !bir.string {
+  // CHECK:      %[[VALUE:.*]] = bir.constant #bir.string<"hello"> : !bir.string
+  // CHECK-NEXT: %[[MEM:.*]] = bir.alloc_heap : !bir.ref<!bir.string>
+  // CHECK-NEXT: bir.store %[[VALUE]] to %[[MEM]] : !bir.string to !bir.ref<!bir.string>
+  %0 = bir.constant #bir.string<"hello"> : !bir.string
+  %1 = bir.declare "x" : !bir.ref<!bir.string>
+  bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+
+  // CHECK:      %[[RET:.*]] = bir.load %[[MEM]] : (!bir.ref<!bir.string>) -> !bir.string
+  // CHECK-NEXT: bir.return %[[RET]] : !bir.string
+  %2 = bir.load %1 : (!bir.ref<!bir.string>) -> !bir.string
+  bir.return %2 : !bir.string
+}

--- a/tests/BIR/Transforms/LowerDeclToMemory/noescape.mlir
+++ b/tests/BIR/Transforms/LowerDeclToMemory/noescape.mlir
@@ -1,0 +1,13 @@
+// RUN: %bir-opt --split-input-file --bir-lower-decl-to-memory %s \
+// RUN: | %FileCheck %s
+
+// CHECK-LABEL: bir.func @main
+bir.func @main() {
+  // CHECK:      %[[VALUE:.*]] = bir.constant #bir.string<"hello"> : !bir.string
+  // CHECK-NEXT: %[[MEM:.*]] = bir.alloc_stack : !bir.ref<!bir.string>
+  // CHECK-NEXT: bir.store %[[VALUE]] to %[[MEM]] : !bir.string to !bir.ref<!bir.string>
+  %0 = bir.constant #bir.string<"hello"> : !bir.string
+  %1 = bir.declare "x" : !bir.ref<!bir.string>
+  bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+  bir.return
+}

--- a/tests/LLVMGen/functions.bel
+++ b/tests/LLVMGen/functions.bel
@@ -5,11 +5,9 @@
 
 # CHECK-LABEL:define i64 @fn.main.anon(
 # CHECK-SAME:     i64 %[[ARG0:.*]], i64 %[[ARG1:.*]]) {
-# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
-# CHECK-NEXT:   %[[V0:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[V0:.*]] = alloca i64, i64 1, align 8
 # CHECK-NEXT:   store i64 %[[ARG0]], ptr %[[V0]], align 4
-# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V0]])
-# CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[V1:.*]] = alloca i64, i64 1, align 8
 # CHECK-NEXT:   store i64 %[[ARG1]], ptr %[[V1]], align 4
 # CHECK-NEXT:   %[[V2:.*]] = load i64, ptr %[[V0]], align 4
 # CHECK-NEXT:   %[[V3:.*]] = load i64, ptr %[[V1]], align 4
@@ -18,8 +16,7 @@
 # CHECK-NEXT: }
 
 # CHECK-LABEL:define i64 @main() {
-# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
-# CHECK-NEXT:   %[[V5:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[V5:.*]] = alloca ptr, i64 1, align 8
 # CHECK-NEXT:   store ptr @fn.main.anon, ptr %[[V5]], align 8
 # CHECK-NEXT:   %[[V6:.*]] = load ptr, ptr %[[V5]], align 8
 # CHECK-NEXT:   %[[V7:.*]] = call i64 %[[V6]](i64 2, i64 3)

--- a/tests/LLVMGen/stackmap.bel
+++ b/tests/LLVMGen/stackmap.bel
@@ -1,11 +1,17 @@
 # RUN: %belalang build --emit=llvm %s | %FileCheck %s
 
 # CHECK-LABEL:define i64 @main() {
-# CHECK:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
-# CHECK-NEXT:   %[[V0:.*]] = call ptr @brt_gc_alloc(i64 8)
-# CHECK:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V0]])
+
+# CHECK:        %[[V0:.*]] = alloca i64, i64 1, align 8
+
+# CHECK:        call void (i64, i32, ...) @llvm.experimental.stackmap(
+# CHECK-SAME:     i64 {{[0-9]+}},
+# CHECK-SAME:     i32 0,
+# CHECK-SAME:     ptr %[[V0]]
+# CHECK-SAME:   )
 # CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
-# CHECK:   ret i64 0
+
+# CHECK:        ret i64 0
 # CHECK-NEXT: }
 
 # CHECK: declare void @llvm.experimental.stackmap(i64 immarg, i32 immarg, ...)


### PR DESCRIPTION
This change implements the initial of EscapeAnalysis in BIR. This makes LowerDeclToMemory dynamic by choosing either AllocStackOp or AllocHeapOp.

Closes #335 