### PR TITLE
[bir] Make arith binops have same type as operands

### DIFF
--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -85,6 +85,7 @@ td_library(
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:FunctionInterfacesTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
         "@llvm-project//mlir:LoopLikeInterfaceTdFiles",
     ],

--- a/include/belalang/BIR/IR/BIR.h
+++ b/include/belalang/BIR/IR/BIR.h
@@ -7,6 +7,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -11,6 +11,7 @@ include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 
@@ -45,7 +46,7 @@ def BIR_ConstantOp : BIR_Op<"constant", [
   let hasVerifier = 1;
 }
 
-def BIR_AddOp : BIR_Op<"add"> {
+def BIR_AddOp : BIR_Op<"add", [SameTypeOperands, SameOperandsAndResultType]> {
   let summary = "add";
 
   let description = [{
@@ -59,11 +60,10 @@ def BIR_AddOp : BIR_Op<"add"> {
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
   let results = (outs BIR_AnyType:$result);
 
-  let assemblyFormat =
-      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_SubOp : BIR_Op<"sub"> {
+def BIR_SubOp : BIR_Op<"sub", [SameTypeOperands, SameOperandsAndResultType]> {
   let summary = "sub";
 
   let description = [{
@@ -77,11 +77,10 @@ def BIR_SubOp : BIR_Op<"sub"> {
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
   let results = (outs BIR_AnyType:$result);
 
-  let assemblyFormat =
-      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_MulOp : BIR_Op<"mul"> {
+def BIR_MulOp : BIR_Op<"mul", [SameTypeOperands, SameOperandsAndResultType]> {
   let summary = "mul";
 
   let description = [{
@@ -95,11 +94,10 @@ def BIR_MulOp : BIR_Op<"mul"> {
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
   let results = (outs BIR_AnyType:$result);
 
-  let assemblyFormat =
-      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_DivOp : BIR_Op<"div"> {
+def BIR_DivOp : BIR_Op<"div", [SameTypeOperands, SameOperandsAndResultType]> {
   let summary = "div";
 
   let description = [{
@@ -113,11 +111,10 @@ def BIR_DivOp : BIR_Op<"div"> {
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
   let results = (outs BIR_AnyType:$result);
 
-  let assemblyFormat =
-      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_ModOp : BIR_Op<"mod"> {
+def BIR_ModOp : BIR_Op<"mod", [SameTypeOperands, SameOperandsAndResultType]> {
   let summary = "mod";
 
   let description = [{
@@ -131,8 +128,7 @@ def BIR_ModOp : BIR_Op<"mod"> {
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
   let results = (outs BIR_AnyType:$result);
 
-  let assemblyFormat =
-      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
 def BIR_AndOp : BIR_Op<"and"> {
@@ -496,14 +492,6 @@ def BIR_CmpOp : BIR_Op<"cmp", [
     $kind $lhs `,` $rhs `:` type($lhs) attr-dict
   }];
 
-  let builders = [
-    OpBuilder<(ins "bir::CmpOpKind":$kind, "::mlir::Value":$lhs, "::mlir::Value":$rhs), [{
-      $_state.addTypes(bir::BoolType::get($_builder.getContext()));
-      $_state.addAttribute("kind", bir::CmpOpKindAttr::get($_builder.getContext(), kind));
-      $_state.addOperands(lhs);
-      $_state.addOperands(rhs);
-    }]>
-  ];
 }
 
 def BIR_GetMemberOp : BIR_Op<"get_member"> {

--- a/tests/BIR/IR/arith.mlir
+++ b/tests/BIR/IR/arith.mlir
@@ -1,18 +1,29 @@
-// RUN: %bir-opt --split-input-file --verify-roundtrip %s | %FileCheck %s
+// RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
 
 // CHECK-LABEL: bir.func @basic
 bir.func @basic() -> !bir.int {
     %0 = bir.constant #bir.int<4> : !bir.int
     %1 = bir.constant #bir.int<2> : !bir.int
-    %2 = bir.add %0, %1 : (!bir.int, !bir.int) -> !bir.int
-    %3 = bir.sub %0, %1 : (!bir.int, !bir.int) -> !bir.int
-    %4 = bir.mul %0, %1 : (!bir.int, !bir.int) -> !bir.int
-    %5 = bir.div %0, %1 : (!bir.int, !bir.int) -> !bir.int
-    %6 = bir.mod %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %2 = bir.add %0, %1 : !bir.int
+    %3 = bir.sub %0, %1 : !bir.int
+    %4 = bir.mul %0, %1 : !bir.int
+    %5 = bir.div %0, %1 : !bir.int
+    %6 = bir.mod %0, %1 : !bir.int
     %7 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %8 = bir.or %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %9 = bir.xor %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %10 = bir.shl %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %11 = bir.shr %0, %1 : (!bir.int, !bir.int) -> !bir.int
     bir.return %0 : !bir.int
+}
+
+// -----
+
+bir.func @mismatched_operands() {
+    %0 = bir.constant #bir.int<4> : !bir.int
+    %1 = bir.constant #bir.float<2.0> : !bir.float
+
+    // expected-error@+1 {{requires all operands to have the same type}}
+    %2 = "bir.add"(%0, %1) : (!bir.int, !bir.float) -> !bir.int
+    bir.return
 }

--- a/tests/BIR/IR/variables.mlir
+++ b/tests/BIR/IR/variables.mlir
@@ -21,7 +21,7 @@ bir.func @main() -> !bir.int {
   // return x + 1
   %2 = bir.constant #bir.int<1> : !bir.int
   %3 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
-  %4 = bir.add %3, %2 : (!bir.int, !bir.int) -> !bir.int
+  %4 = bir.add %3, %2 : !bir.int
   bir.return %4 : !bir.int
 }
 

--- a/tests/BIR/Transforms/BIRToLLVM/arith.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/arith.mlir
@@ -11,19 +11,19 @@ bir.func @basic() -> !bir.int {
   %1 = bir.constant #bir.int<2> : !bir.int
 
   // CHECK-NEXT: %2 = llvm.add %0, %1 : i64
-  %2 = bir.add %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %2 = bir.add %0, %1 : !bir.int
 
   // CHECK-NEXT: %3 = llvm.sub %0, %1 : i64
-  %3 = bir.sub %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %3 = bir.sub %0, %1 : !bir.int
 
   // CHECK-NEXT: %4 = llvm.mul %0, %1 : i64
-  %4 = bir.mul %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %4 = bir.mul %0, %1 : !bir.int
 
   // CHECK-NEXT: %5 = llvm.sdiv %0, %1 : i64
-  %5 = bir.div %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %5 = bir.div %0, %1 : !bir.int
 
   // CHECK-NEXT: %6 = llvm.srem %0, %1 : i64
-  %6 = bir.mod %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %6 = bir.mod %0, %1 : !bir.int
 
   // CHECK-NEXT: %7 = llvm.and %0, %1 : i64
   %7 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int

--- a/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
+++ b/tests/BIR/Transforms/InsertStackMaps/insert-stackmaps.mlir
@@ -11,7 +11,7 @@
 // CHECK-NEXT:   bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
 // CHECK-NEXT:   %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:   %5 = bir.constant #bir.int<1> : !bir.int
-// CHECK-NEXT:   %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
+// CHECK-NEXT:   %6 = bir.add %4, %5 : !bir.int
 // CHECK-NEXT:   bir.safepoint 2(%1, %3 : !bir.ref<!bir.int>, !bir.ref<!bir.float>)
 // CHECK-NEXT:   %7 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
@@ -28,7 +28,7 @@ bir.func @alloc_straight_line() -> !bir.int {
   bir.store %2 to %3 : !bir.float to !bir.ref<!bir.float>
   %4 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
   %5 = bir.constant #bir.int<1> : !bir.int
-  %6 = bir.add %4, %5 : (!bir.int, !bir.int) -> !bir.int
+  %6 = bir.add %4, %5 : !bir.int
   %7 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %6 to %7 : !bir.int to !bir.ref<!bir.int>
   %8 = bir.load %7 : (!bir.ref<!bir.int>) -> !bir.int
@@ -46,7 +46,7 @@ bir.func @alloc_straight_line() -> !bir.int {
 // CHECK-NEXT: ^bb1:  // pred: ^bb0
 // CHECK-NEXT:   %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:   %3 = bir.constant #bir.int<1> : !bir.int
-// CHECK-NEXT:   %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
+// CHECK-NEXT:   %4 = bir.add %2, %3 : !bir.int
 // CHECK-NEXT:   bir.safepoint 1(%1 : !bir.ref<!bir.int>)
 // CHECK-NEXT:   %5 = bir.alloc_heap : !bir.ref<!bir.int>
 // CHECK-NEXT:   bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
@@ -62,7 +62,7 @@ bir.func @alloc_cross_block() -> !bir.int {
 ^bb1:
   %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
   %3 = bir.constant #bir.int<1> : !bir.int
-  %4 = bir.add %2, %3 : (!bir.int, !bir.int) -> !bir.int
+  %4 = bir.add %2, %3 : !bir.int
   %5 = bir.alloc_heap : !bir.ref<!bir.int>
   bir.store %4 to %5 : !bir.int to !bir.ref<!bir.int>
   %6 = bir.load %5 : (!bir.ref<!bir.int>) -> !bir.int

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -9,7 +9,7 @@
 # CHECK-NEXT:       bir.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:       %[[V2:.*]] = bir.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:       %[[V3:.*]] = bir.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:       %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT:       %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : !bir.int
 # CHECK-NEXT:       bir.return %[[V4]] : !bir.int
 # CHECK-NEXT:     }
 # CHECK-NEXT:     %[[V5:.*]] = bir.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>

--- a/tests/BIRGen/infix.bel
+++ b/tests/BIRGen/infix.bel
@@ -4,14 +4,14 @@
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
-# CHECK-NEXT: %[[C2:.*]] = bir.add %[[C0]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C2:.*]] = bir.add %[[C0]], %[[C1]] : !bir.int
 1 + 2;
 
 # CHECK-NEXT: %[[C3:.*]] = bir.constant #bir.int<10> : !bir.int
 # CHECK-NEXT: %[[C4:.*]] = bir.constant #bir.int<2> : !bir.int
-# CHECK-NEXT: %[[C5:.*]] = bir.div %[[C3]], %[[C4]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C5:.*]] = bir.div %[[C3]], %[[C4]] : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.constant #bir.int<2> : !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.mul %[[C5]], %[[C6]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C7:.*]] = bir.mul %[[C5]], %[[C6]] : !bir.int
 10 / 2 * 2;
 
 # CHECK-NEXT: %8 = bir.constant #bir.int<0> : !bir.int

--- a/tests/BIRGen/var-expr.bel
+++ b/tests/BIRGen/var-expr.bel
@@ -8,31 +8,31 @@ x := 0;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C3:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C4:.*]] = bir.add %[[C3]], %[[C2]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C4:.*]] = bir.add %[[C3]], %[[C2]] : !bir.int
 # CHECK-NEXT: bir.store %[[C4]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x += 1;
 
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.sub %[[C6]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C7:.*]] = bir.sub %[[C6]], %[[C5]] : !bir.int
 # CHECK-NEXT: bir.store %[[C7]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x -= 1;
 
 # CHECK-NEXT: %[[C8:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C9:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C10:.*]] = bir.mul %[[C9]], %[[C8]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C10:.*]] = bir.mul %[[C9]], %[[C8]] : !bir.int
 # CHECK-NEXT: bir.store %[[C10]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x *= 1;
 
 # CHECK-NEXT: %[[C11:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C12:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C13:.*]] = bir.div %[[C12]], %[[C11]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C13:.*]] = bir.div %[[C12]], %[[C11]] : !bir.int
 # CHECK-NEXT: bir.store %[[C13]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x /= 1;
 
 # CHECK-NEXT: %[[C14:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C15:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C16:.*]] = bir.mod %[[C15]], %[[C14]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C16:.*]] = bir.mod %[[C15]], %[[C14]] : !bir.int
 # CHECK-NEXT: bir.store %[[C16]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x %= 1;
 

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -14,7 +14,7 @@ y := 1.0;
 
 # CHECK-NEXT: %[[C4:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : !bir.int
 # CHECK-NEXT: %[[C7:.*]] = bir.declare "z" : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT: %[[C8:.*]] = bir.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
@@ -29,7 +29,7 @@ x = 10;
 
 # CHECK-NEXT: %[[C11:.*]] = bir.constant #bir.int<5> : !bir.int
 # CHECK-NEXT: %[[C12:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT: %[[C13:.*]] = bir.add %[[C12]], %[[C11]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT: %[[C13:.*]] = bir.add %[[C12]], %[[C11]] : !bir.int
 # CHECK-NEXT: bir.store %[[C13]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x += 5;
 

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -13,7 +13,7 @@
 # CHECK-NEXT:       bir.scope {
 # CHECK-NEXT:         %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:         %[[L2:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:         %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT:         %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : !bir.int
 # CHECK-NEXT:         bir.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:         bir.yield
 # CHECK-NEXT:       }


### PR DESCRIPTION
This change makes the arithmetic binary operations (add, sub, div, mul, mod) to have SameTypeOperands, SameOperandsAndResultType. BIR ops should be low enough that the inputs to these ops should have gone through casting or conversion.