### PR TITLE
[bir] Rename VarLoadOp -> LoadOp

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -343,7 +343,7 @@ def BIR_StoreOp : BIR_Op<"store"> {
   let assemblyFormat = "$src `to` $dest attr-dict `:` type($src) `to` qualified(type($dest))";
 }
 
-def BIR_VarLoadOp : BIR_Op<"load"> {
+def BIR_LoadOp : BIR_Op<"load"> {
   let summary = "load";
 
   let arguments = (ins BIR_RefType:$ref);

--- a/lib/BIR/Analysis/EscapeAnalysis.cpp
+++ b/lib/BIR/Analysis/EscapeAnalysis.cpp
@@ -39,7 +39,7 @@ EscapeAnalysis::visitOperation(mlir::Operation *op,
     }
   }
 
-  if (mlir::isa<bir::VarLoadOp>(op) && !results.empty() &&
+  if (mlir::isa<bir::LoadOp>(op) && !results.empty() &&
       results.front()->escapes) {
     propagateIfChanged(operands.front(), operands.front()->markEscapes());
   }

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -560,11 +560,11 @@ struct StoreOpLowering final : public OpConversionPattern<bir::StoreOp> {
   };
 };
 
-struct VarLoadOpLowering final : public OpConversionPattern<bir::VarLoadOp> {
-  using OpConversionPattern<bir::VarLoadOp>::OpConversionPattern;
+struct LoadOpLowering final : public OpConversionPattern<bir::LoadOp> {
+  using OpConversionPattern<bir::LoadOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(bir::VarLoadOp op, OpAdaptor adaptor,
+  matchAndRewrite(bir::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto type = getTypeConverter()->convertType(op.getType());
     if (!type)
@@ -824,9 +824,9 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
                ShrOpLowering, AllocHeapOpLowering, AllocStackOpLowering,
-               StoreOpLowering, VarLoadOpLowering, CondBrLowering,
-               CmpOpLowering, GetMemberOpLowering, SafepointOpLowering>(
-      typeConverter, patterns.getContext());
+               StoreOpLowering, LoadOpLowering, CondBrLowering, CmpOpLowering,
+               GetMemberOpLowering, SafepointOpLowering>(typeConverter,
+                                                         patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/BIRGen/BIRGen.cpp
+++ b/lib/BIRGen/BIRGen.cpp
@@ -229,8 +229,7 @@ mlir::Value BIRGen::visitVarExpr(VarExpr *expr) {
   }
 
   auto refType = llvm::cast<bir::RefType>(dest.getType());
-  auto loadOp =
-      bir::VarLoadOp::create(builder, loc, refType.getReferent(), dest);
+  auto loadOp = bir::LoadOp::create(builder, loc, refType.getReferent(), dest);
   mlir::Value lhs = loadOp.getResult();
 
   mlir::Value res;
@@ -349,8 +348,7 @@ mlir::Value BIRGen::visitIdentifierExpr(IdentifierExpr *expr) {
 
   mlir::Value ref = it->second;
   auto refType = llvm::cast<bir::RefType>(ref.getType());
-  auto loadOp =
-      bir::VarLoadOp::create(builder, loc, refType.getReferent(), ref);
+  auto loadOp = bir::LoadOp::create(builder, loc, refType.getReferent(), ref);
   return loadOp.getResult();
 }
 


### PR DESCRIPTION
Renames `VarLoadOp` to `LoadOp`. We renamed the `var.` prefix on operations in #292. The `VarLoadOp` rename was missed in that PR.