### PR TITLE
[bir][LowerFuncExpr] Hoist AllocStackOp to start of function body

### DIFF
--- a/lib/BIR/Transforms/LowerFuncExpr.cpp
+++ b/lib/BIR/Transforms/LowerFuncExpr.cpp
@@ -55,6 +55,32 @@ struct BelalangLowerFuncExprPass
   using impl::BelalangLowerFuncExprPassBase<
       BelalangLowerFuncExprPass>::BelalangLowerFuncExprPassBase;
 
+  /// Hoists AllocStackOps to the start of the current function body.
+  void hoistAllocStackOps() {
+    mlir::Operation *op = getOperation();
+
+    op->walk<mlir::WalkOrder::PreOrder>([&](bir::FuncOp fn) {
+      if (fn.getRegion().empty())
+        return;
+
+      mlir::Block &entry = fn.getBody().front();
+      mlir::Operation *lastHoisted = nullptr;
+
+      fn.getBody().walk<mlir::WalkOrder::PostOrder>([&](bir::AllocStackOp op) {
+        if (op->getParentOfType<bir::FuncOp>() != fn ||
+            op->getBlock() == &entry)
+          return;
+
+        if (lastHoisted)
+          op->moveAfter(lastHoisted);
+        else
+          op->moveBefore(&entry, entry.begin());
+
+        lastHoisted = op;
+      });
+    });
+  }
+
   void runOnOperation() override {
     mlir::RewritePatternSet patterns(&getContext());
     belalang::bir::populateBelalangLowerFuncExprPatterns(patterns);
@@ -63,6 +89,8 @@ struct BelalangLowerFuncExprPass
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
+
+    hoistAllocStackOps();
   }
 };
 

--- a/tests/BIR/Transforms/LowerFuncExpr/lower-func-expr.mlir
+++ b/tests/BIR/Transforms/LowerFuncExpr/lower-func-expr.mlir
@@ -67,3 +67,19 @@ bir.func @void_return() {
   }
   bir.return
 }
+
+// -----
+
+// Allocations from nested regions are hoisted in source order.
+// CHECK-LABEL: bir.func @hoist_alloc_stack
+// CHECK-NEXT: %[[FIRST:.*]] = bir.alloc_stack : !bir.ref<!bir.int>
+// CHECK-NEXT: %[[SECOND:.*]] = bir.alloc_stack : !bir.ref<!bir.int>
+// CHECK-NEXT: bir.scope
+bir.func @hoist_alloc_stack() {
+  bir.scope {
+    %first = bir.alloc_stack : !bir.ref<!bir.int>
+    %second = bir.alloc_stack : !bir.ref<!bir.int>
+    bir.yield
+  }
+  bir.return
+}


### PR DESCRIPTION
This change implements a hoisting mechanism to hoist the AllocStackOps to the start of the enclosing function body. I saw this behavior happening in ClangIR through their `HoistAllocas` pass. This is the BIR version of said pass.