### PR TITLE
[chore][bir] Remove using namespace in BIR.h

### DIFF
--- a/include/belalang/BIR/IR/BIR.h
+++ b/include/belalang/BIR/IR/BIR.h
@@ -15,9 +15,6 @@
 
 #include "belalang/BIR/Interfaces/LoopOpInterface.h"
 
-using namespace mlir;
-using namespace llvm;
-
 #include "belalang/BIR/IR/BIRDialect.h.inc"
 #include "belalang/BIR/IR/BIREnumAttrs.h.inc"
 

--- a/include/belalang/BIR/IR/BIRAttrs.td
+++ b/include/belalang/BIR/IR/BIRAttrs.td
@@ -62,7 +62,7 @@ def BIR_FnAttr : BIR_Attr<"Fn", "fn", [TypedAttrInterface]> {
 
   let parameters = (ins
     AttributeSelfTypeParameter<"">:$type,
-    "FlatSymbolRefAttr":$value
+    "mlir::FlatSymbolRefAttr":$value
   );
 
   let assemblyFormat = "`<` $value `>`";

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -217,9 +217,9 @@ def BIR_FuncOp : BIR_Op<"func", [FunctionOpInterface, CallableOpInterface,
 
     ::mlir::Region *getCallableRegion() { return &getBody(); }
 
-    ArrayRef<::mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ::llvm::ArrayRef<::mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
-    ArrayRef<::mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
+    ::llvm::ArrayRef<::mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
 
     mlir::Type getResType();
   }];
@@ -271,12 +271,12 @@ def BIR_CallIndirectOp : BIR_Op<"call_indirect", [
   TypesMatchWith<
     "callee input types match argument types",
     "callee", "callee_operands",
-    "::llvm::cast<FunctionType>($_self).getInputs()"
+    "::llvm::cast<::mlir::FunctionType>($_self).getInputs()"
   >,
   TypesMatchWith<
     "callee result types match result types",
     "callee", "results",
-    "::llvm::cast<FunctionType>($_self).getResults()"
+    "::llvm::cast<::mlir::FunctionType>($_self).getResults()"
   >
 ]> {
   let summary = "call_indirect";
@@ -297,16 +297,16 @@ def BIR_CallIndirectOp : BIR_Op<"call_indirect", [
       return {operand_begin(), operand_end()};
     }
 
-    MutableOperandRange getArgOperandsMutable() {
+    ::mlir::MutableOperandRange getArgOperandsMutable() {
       return getCalleeOperandsMutable();
     }
 
-    CallInterfaceCallable getCallableForCallee() {
+    ::mlir::CallInterfaceCallable getCallableForCallee() {
       return getCallee();
     }
 
-    void setCalleeFromCallable(CallInterfaceCallable callee) {
-      setOperand(0, cast<mlir::Value>(callee));
+    void setCalleeFromCallable(::mlir::CallInterfaceCallable callee) {
+      setOperand(0, mlir::cast<mlir::Value>(callee));
     }
   }];
 }
@@ -386,7 +386,7 @@ def BIR_IfOp : BIR_Op<"if", [
 
   let extraClassDeclaration = [{
     bool hasElse() { return !getElseRegion().empty(); }
-    static LogicalResult ensureRegionTerm(::mlir::Builder &, ::mlir::Region &);
+    static ::mlir::LogicalResult ensureRegionTerm(::mlir::Builder &, ::mlir::Region &);
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/lib/BIR/Analysis/EscapeAnalysis.cpp
+++ b/lib/BIR/Analysis/EscapeAnalysis.cpp
@@ -49,8 +49,9 @@ EscapeAnalysis::visitOperation(mlir::Operation *op,
 
 void EscapeAnalysis::visitBranchOperand(mlir::OpOperand &operand) {
   mlir::Operation *op = operand.getOwner();
-  assert(isa<RegionBranchOpInterface>(op) || isa<BranchOpInterface>(op) ||
-         isa<RegionBranchTerminatorOpInterface>(op));
+  assert(mlir::isa<mlir::RegionBranchOpInterface>(op) ||
+         mlir::isa<mlir::BranchOpInterface>(op) ||
+         mlir::isa<mlir::RegionBranchTerminatorOpInterface>(op));
 
   auto *visitOp = mlir::isa<mlir::RegionBranchTerminatorOpInterface>(op)
                       ? op->getParentOp()
@@ -67,7 +68,7 @@ void EscapeAnalysis::visitBranchOperand(mlir::OpOperand &operand) {
 
 void EscapeAnalysis::visitCallOperand(mlir::OpOperand &operand) {
   mlir::Operation *op = operand.getOwner();
-  assert(mlir::isa<CallOpInterface>(op));
+  assert(mlir::isa<mlir::CallOpInterface>(op));
 
   EscapeLattice *lattice = getLatticeElement(operand.get());
   propagateIfChanged(lattice, lattice->markEscapes());

--- a/lib/BIR/IR/BIRDialect.cpp
+++ b/lib/BIR/IR/BIRDialect.cpp
@@ -14,16 +14,16 @@
 namespace {
 using namespace belalang;
 
-struct BIROpAsmDialectInterface : public OpAsmDialectInterface {
-  using OpAsmDialectInterface::OpAsmDialectInterface;
+struct BIROpAsmDialectInterface : public mlir::OpAsmDialectInterface {
+  using mlir::OpAsmDialectInterface::OpAsmDialectInterface;
 
-  AliasResult getAlias(Type type, raw_ostream &os) const override {
-    if (auto structType = dyn_cast<bir::StructType>(type)) {
+  AliasResult getAlias(mlir::Type type, llvm::raw_ostream &os) const override {
+    if (auto structType = mlir::dyn_cast<bir::StructType>(type)) {
       auto nameAttr = structType.getName();
       os << "struct_" << nameAttr.getValue();
-      return AliasResult::OverridableAlias;
+      return mlir::OpAsmAliasResult::OverridableAlias;
     }
-    return AliasResult::NoAlias;
+    return mlir::OpAsmAliasResult::NoAlias;
   }
 };
 } // namespace

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -18,32 +18,32 @@ namespace bir {
 // ConstantOp
 // -----------------------------------------------------------------------------
 
-LogicalResult ConstantOp::verify() {
+mlir::LogicalResult ConstantOp::verify() {
   mlir::Type ty = getType();
   mlir::Attribute attr = getValue();
 
-  if (isa<bir::IntType>(ty) && isa<bir::IntegerAttr>(attr)) {
-    return success();
+  if (mlir::isa<bir::IntType>(ty) && mlir::isa<bir::IntegerAttr>(attr)) {
+    return mlir::success();
   }
 
-  if (isa<bir::FloatType>(ty) && isa<bir::FloatAttr>(attr)) {
-    return success();
+  if (mlir::isa<bir::FloatType>(ty) && mlir::isa<bir::FloatAttr>(attr)) {
+    return mlir::success();
   }
 
-  if (isa<bir::StringType>(ty) && isa<bir::StringAttr>(attr)) {
-    return success();
+  if (mlir::isa<bir::StringType>(ty) && mlir::isa<bir::StringAttr>(attr)) {
+    return mlir::success();
   }
 
-  if (isa<FunctionType>(ty) && isa<bir::FnAttr>(attr)) {
-    return success();
+  if (mlir::isa<mlir::FunctionType>(ty) && mlir::isa<bir::FnAttr>(attr)) {
+    return mlir::success();
   }
 
-  if (isa<bir::BoolType>(ty) && isa<bir::BoolAttr>(attr)) {
-    return success();
+  if (mlir::isa<bir::BoolType>(ty) && mlir::isa<bir::BoolAttr>(attr)) {
+    return mlir::success();
   }
 
-  if (isa<bir::StructType>(ty) && isa<bir::StructAttr>(attr)) {
-    return success();
+  if (mlir::isa<bir::StructType>(ty) && mlir::isa<bir::StructAttr>(attr)) {
+    return mlir::success();
   }
 
   return emitOpError() << "type and attribute mismatch.";
@@ -92,11 +92,11 @@ mlir::Type FuncOp::getResType() {
 // FuncExprOp
 // -----------------------------------------------------------------------------
 
-LogicalResult FuncExprOp::verify() {
+mlir::LogicalResult FuncExprOp::verify() {
   auto &body = getBody().front();
   auto term = body.getTerminator();
 
-  auto returnOp = dyn_cast_or_null<bir::ReturnOp>(term);
+  auto returnOp = mlir::dyn_cast_or_null<bir::ReturnOp>(term);
   if (!returnOp)
     return emitOpError() << "body must be terminated by a 'bir.return' op";
 
@@ -106,7 +106,7 @@ LogicalResult FuncExprOp::verify() {
     return emitOpError() << "returned types do not match function signature types";
   }
 
-  return success();
+  return mlir::success();
 }
 
 // -----------------------------------------------------------------------------
@@ -149,13 +149,13 @@ mlir::ParseResult CallOp::parse(mlir::OpAsmParser &parser,
   if (parser.parseColon())
     return mlir::failure();
 
-  SmallVector<Type> argTypes;
-  SmallVector<DictionaryAttr> argAttrs;
-  SmallVector<Type> resultTypes;
-  SmallVector<DictionaryAttr> resultAttrs;
+  llvm::SmallVector<mlir::Type> argTypes;
+  llvm::SmallVector<mlir::DictionaryAttr> argAttrs;
+  llvm::SmallVector<mlir::Type> resultTypes;
+  llvm::SmallVector<mlir::DictionaryAttr> resultAttrs;
 
-  if (call_interface_impl::parseFunctionSignature(parser, argTypes, argAttrs,
-                                                  resultTypes, resultAttrs))
+  if (mlir::call_interface_impl::parseFunctionSignature(
+          parser, argTypes, argAttrs, resultTypes, resultAttrs))
     return mlir::failure();
 
   result.addTypes(resultTypes);
@@ -172,7 +172,7 @@ void CallOp::print(mlir::OpAsmPrinter &p) {
   p << '(' << getArgOperands() << ')';
   p << " : ";
 
-  call_interface_impl::printFunctionSignature(
+  mlir::call_interface_impl::printFunctionSignature(
       p, getOperands().getTypes(), getArgAttrsAttr(), false,
       (*this)->getResultTypes(), getResAttrsAttr());
 }
@@ -183,7 +183,7 @@ void CallOp::print(mlir::OpAsmPrinter &p) {
 
 mlir::LogicalResult
 CallOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
-  auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
+  auto fnAttr = (*this)->getAttrOfType<mlir::FlatSymbolRefAttr>("callee");
   auto fn = symbolTable.lookupNearestSymbolFrom<bir::FuncOp>(*this, fnAttr);
 
   if (!fn)
@@ -221,13 +221,13 @@ mlir::LogicalResult IfOp::ensureRegionTerm(mlir::Builder &b, mlir::Region &r) {
     builder.createBlock(&r);
 
   mlir::Block &blk = r.back();
-  if (!blk.empty() && blk.back().hasTrait<OpTrait::IsTerminator>())
-    return success();
+  if (!blk.empty() && blk.back().hasTrait<mlir::OpTrait::IsTerminator>())
+    return mlir::success();
 
   // Create the yield op to terminate the block
   builder.setInsertionPointToEnd(&blk);
   bir::YieldOp::create(builder, builder.getUnknownLoc());
-  return success();
+  return mlir::success();
 }
 
 mlir::ParseResult IfOp::parse(mlir::OpAsmParser &p, mlir::OperationState &result) {
@@ -235,22 +235,23 @@ mlir::ParseResult IfOp::parse(mlir::OpAsmParser &p, mlir::OperationState &result
   mlir::Region *thenRegion = result.addRegion();
   mlir::Region *elseRegion = result.addRegion();
 
-  OpAsmParser::UnresolvedOperand cond;
+  mlir::OpAsmParser::UnresolvedOperand cond;
   mlir::Type ty = bir::BoolType::get(p.getContext());
 
-  if (failed(p.parseOperand(cond)) || failed(p.resolveOperand(cond, ty, result.operands)))
-    return failure();
+  if (mlir::failed(p.parseOperand(cond)) ||
+      mlir::failed(p.resolveOperand(cond, ty, result.operands)))
+    return mlir::failure();
 
-  if (failed(p.parseRegion(*thenRegion)))
-    return failure();
-  if (failed(ensureRegionTerm(p.getBuilder(), *thenRegion)))
-    return failure();
+  if (mlir::failed(p.parseRegion(*thenRegion)))
+    return mlir::failure();
+  if (mlir::failed(ensureRegionTerm(p.getBuilder(), *thenRegion)))
+    return mlir::failure();
 
-  if (succeeded(p.parseOptionalKeyword("else"))) {
-    if (failed(p.parseRegion(*elseRegion)))
-      return failure();
-    if (failed(ensureRegionTerm(p.getBuilder(), *elseRegion)))
-      return failure();
+  if (mlir::succeeded(p.parseOptionalKeyword("else"))) {
+    if (mlir::failed(p.parseRegion(*elseRegion)))
+      return mlir::failure();
+    if (mlir::failed(ensureRegionTerm(p.getBuilder(), *elseRegion)))
+      return mlir::failure();
   }
 
   if (p.parseOptionalColon().succeeded()) {
@@ -260,14 +261,14 @@ mlir::ParseResult IfOp::parse(mlir::OpAsmParser &p, mlir::OperationState &result
 
     mlir::Type resultTy;
     if (p.parseType(resultTy).failed())
-      return failure();
+      return mlir::failure();
     result.addTypes(resultTy);
   }
 
-  if (failed(p.parseOptionalAttrDict(result.attributes)))
-    return failure();
+  if (mlir::failed(p.parseOptionalAttrDict(result.attributes)))
+    return mlir::failure();
 
-  return success();
+  return mlir::success();
 }
 
 void IfOp::print(mlir::OpAsmPrinter &p) {
@@ -287,10 +288,10 @@ void IfOp::print(mlir::OpAsmPrinter &p) {
 // ConditionOp
 // -----------------------------------------------------------------------------
 
-LogicalResult bir::ConditionOp::verify() {
-  if (!isa<LoopOpInterface>(getOperation()->getParentOp()))
+mlir::LogicalResult bir::ConditionOp::verify() {
+  if (!mlir::isa<LoopOpInterface>(getOperation()->getParentOp()))
     return emitOpError("must be within a conditional region");
-  return success();
+  return mlir::success();
 }
 
 } // namespace bir

--- a/lib/BIR/IR/BIRTypes.cpp
+++ b/lib/BIR/IR/BIRTypes.cpp
@@ -21,7 +21,7 @@ mlir::Type StructType::parse(mlir::AsmParser &p) {
 
   // Matches optional `>`.
   // This parses a struct type without a body used in self-referencing types.
-  SMLoc greaterLoc = p.getCurrentLocation();
+  mlir::SMLoc greaterLoc = p.getCurrentLocation();
   if (p.parseOptionalGreater().succeeded()) {
     auto nameAttr = p.getBuilder().getStringAttr(name);
     auto structTy = StructType::get(ctx, {}, nameAttr);
@@ -50,9 +50,10 @@ mlir::Type StructType::parse(mlir::AsmParser &p) {
     return {};
 
   // `{<member1>, <member2>, ..., <membern>}`
-  if (p.parseCommaSeparatedList(AsmParser::Delimiter::Braces, [&p, &members]() {
-         return p.parseType(members.emplace_back());
-       }).failed())
+  if (p.parseCommaSeparatedList(
+           mlir::AsmParser::Delimiter::Braces,
+           [&p, &members]() { return p.parseType(members.emplace_back()); })
+          .failed())
     return {};
 
   // `>`
@@ -67,7 +68,7 @@ mlir::Type StructType::parse(mlir::AsmParser &p) {
 }
 
 void StructType::print(mlir::AsmPrinter &p) const {
-  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrint;
+  mlir::FailureOr<mlir::AsmPrinter::CyclicPrintReset> cyclicPrint;
 
   p << '<';
   cyclicPrint = p.tryStartCyclicPrint(*this);

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -834,8 +834,8 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
 // -----------------------------------------------------------------------------
 
 struct BelalangBIRToLLVMPass
-    : public impl::BelalangBIRToLLVMPassBase<BelalangBIRToLLVMPass> {
-  using impl::BelalangBIRToLLVMPassBase<
+    : public mlir::impl::BelalangBIRToLLVMPassBase<BelalangBIRToLLVMPass> {
+  using mlir::impl::BelalangBIRToLLVMPassBase<
       BelalangBIRToLLVMPass>::BelalangBIRToLLVMPassBase;
 
   void runOnOperation() override {

--- a/lib/BIR/Transforms/FlattenCFG.cpp
+++ b/lib/BIR/Transforms/FlattenCFG.cpp
@@ -15,7 +15,7 @@ using namespace belalang::bir;
 
 class BIRScopeOpFlattening : public mlir::OpRewritePattern<bir::ScopeOp> {
 public:
-  using OpRewritePattern<bir::ScopeOp>::OpRewritePattern;
+  using mlir::OpRewritePattern<bir::ScopeOp>::OpRewritePattern;
 
   mlir::LogicalResult
   matchAndRewrite(bir::ScopeOp op,
@@ -35,27 +35,28 @@ public:
     rewriter.inlineRegionBefore(op.getScopeRegion(), continueBlock);
 
     rewriter.setInsertionPointToEnd(currentBlock);
-    cf::BranchOp::create(rewriter, op.getLoc(), mlir::ValueRange(), beforeBody);
+    mlir::cf::BranchOp::create(rewriter, op.getLoc(), mlir::ValueRange(),
+                               beforeBody);
 
     rewriter.setInsertionPointToEnd(afterBody);
-    if (auto yieldOp = dyn_cast<bir::YieldOp>(afterBody->getTerminator()))
-      rewriter.replaceOpWithNewOp<cf::BranchOp>(yieldOp, yieldOp.getArgs(),
-                                                continueBlock);
+    if (auto yieldOp = mlir::dyn_cast<bir::YieldOp>(afterBody->getTerminator()))
+      rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(
+          yieldOp, yieldOp.getArgs(), continueBlock);
 
     rewriter.replaceOp(op, continueBlock->getArguments());
 
-    return success();
+    return mlir::success();
   }
 };
 
 class BIRIfOpFlattening : public mlir::OpRewritePattern<bir::IfOp> {
 public:
-  using OpRewritePattern<bir::IfOp>::OpRewritePattern;
+  using mlir::OpRewritePattern<bir::IfOp>::OpRewritePattern;
 
   mlir::LogicalResult
   matchAndRewrite(bir::IfOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    OpBuilder::InsertionGuard guard(rewriter);
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
 
     mlir::Block *currentBlock = rewriter.getInsertionBlock();
     mlir::Block *continueBlock =
@@ -71,9 +72,9 @@ public:
     rewriter.inlineRegionBefore(op.getThenRegion(), continueBlock);
 
     if (auto thenYieldOp =
-            dyn_cast<bir::YieldOp>(thenAfterBody->getTerminator())) {
+            mlir::dyn_cast<bir::YieldOp>(thenAfterBody->getTerminator())) {
       rewriter.setInsertionPointToEnd(thenAfterBody);
-      rewriter.replaceOpWithNewOp<cf::BranchOp>(
+      rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(
           thenYieldOp, thenYieldOp.getArgs(), continueBlock);
     }
 
@@ -89,9 +90,9 @@ public:
     }
 
     if (auto elseYieldOp =
-            dyn_cast<bir::YieldOp>(elseAfterBody->getTerminator())) {
+            mlir::dyn_cast<bir::YieldOp>(elseAfterBody->getTerminator())) {
       rewriter.setInsertionPointToEnd(elseAfterBody);
-      rewriter.replaceOpWithNewOp<cf::BranchOp>(
+      rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(
           elseYieldOp, elseYieldOp.getArgs(), continueBlock);
     }
 
@@ -101,7 +102,7 @@ public:
                           elseBeforeBody);
 
     rewriter.replaceOp(op, continueBlock->getArguments());
-    return success();
+    return mlir::success();
   }
 };
 
@@ -125,13 +126,13 @@ public:
 
     // Loop entry branch.
     rewriter.setInsertionPointToEnd(currentBlock);
-    cf::BranchOp::create(rewriter, op.getLoc(), entry);
+    mlir::cf::BranchOp::create(rewriter, op.getLoc(), entry);
 
     // Lower condition.
     auto conditionOp =
-        cast<bir::ConditionOp>(op.getCond().back().getTerminator());
+        mlir::cast<bir::ConditionOp>(op.getCond().back().getTerminator());
     {
-      OpBuilder::InsertionGuard guard(rewriter);
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(conditionOp);
       rewriter.replaceOpWithNewOp<bir::CondBrOp>(
           conditionOp, conditionOp.getCond(), body, exit);
@@ -139,23 +140,23 @@ public:
 
     // Replace continues and breaks with branch op.
     op.walk([&](mlir::Operation *op) {
-      if (isa<bir::BreakOp>(op)) {
-        OpBuilder::InsertionGuard guard(rewriter);
+      if (mlir::isa<bir::BreakOp>(op)) {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointAfter(op);
-        rewriter.replaceOpWithNewOp<cf::BranchOp>(op, exit);
+        rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(op, exit);
       }
-      if (isa<bir::ContinueOp>(op)) {
-        OpBuilder::InsertionGuard guard(rewriter);
+      if (mlir::isa<bir::ContinueOp>(op)) {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointAfter(op);
-        rewriter.replaceOpWithNewOp<cf::BranchOp>(op, cond);
+        rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(op, cond);
       }
     });
 
     // Lower yield terminator.
     for (mlir::Block &blk : op.getBody().getBlocks()) {
-      if (auto yield = dyn_cast<bir::YieldOp>(blk.getTerminator())) {
+      if (auto yield = mlir::dyn_cast<bir::YieldOp>(blk.getTerminator())) {
         rewriter.setInsertionPointToEnd(&op.getBody().back());
-        rewriter.replaceOpWithNewOp<cf::BranchOp>(yield, cond);
+        rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(yield, cond);
       }
     }
 
@@ -165,7 +166,7 @@ public:
 
     // Yay!
     rewriter.eraseOp(op);
-    return success();
+    return mlir::success();
   }
 };
 
@@ -182,17 +183,17 @@ void belalang::bir::populateBelalangFlattenCFGPatterns(
 }
 
 struct BelalangFlattenCFGPass
-    : public impl::BelalangFlattenCFGPassBase<BelalangFlattenCFGPass> {
-  using impl::BelalangFlattenCFGPassBase<
+    : public mlir::impl::BelalangFlattenCFGPassBase<BelalangFlattenCFGPass> {
+  using mlir::impl::BelalangFlattenCFGPassBase<
       BelalangFlattenCFGPass>::BelalangFlattenCFGPassBase;
 
   void runOnOperation() override {
     mlir::RewritePatternSet patterns(&getContext());
     belalang::bir::populateBelalangFlattenCFGPatterns(patterns);
 
-    llvm::SmallVector<Operation *, 16> ops;
-    getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-      if (isa<ScopeOp, IfOp, WhileOp>(op))
+    llvm::SmallVector<mlir::Operation *, 16> ops;
+    getOperation()->walk<mlir::WalkOrder::PostOrder>([&](mlir::Operation *op) {
+      if (mlir::isa<ScopeOp, IfOp, WhileOp>(op))
         ops.push_back(op);
     });
 

--- a/lib/BIR/Transforms/InsertStackMaps.cpp
+++ b/lib/BIR/Transforms/InsertStackMaps.cpp
@@ -14,9 +14,9 @@ using namespace belalang;
 using namespace belalang::bir;
 
 struct BelalangInsertStackMapsPass
-    : public impl::BelalangInsertStackMapsPassBase<
+    : public mlir::impl::BelalangInsertStackMapsPassBase<
           BelalangInsertStackMapsPass> {
-  using impl::BelalangInsertStackMapsPassBase<
+  using mlir::impl::BelalangInsertStackMapsPassBase<
       BelalangInsertStackMapsPass>::BelalangInsertStackMapsPassBase;
 
   void runOnOperation() override {

--- a/lib/BIR/Transforms/LowerDeclToMemory.cpp
+++ b/lib/BIR/Transforms/LowerDeclToMemory.cpp
@@ -15,11 +15,11 @@ namespace {
 using namespace belalang;
 using namespace belalang::bir;
 
-struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
+struct DeclareOpLowering final : public mlir::OpRewritePattern<bir::DeclareOp> {
   DeclareOpLowering(mlir::MLIRContext *ctx, mlir::DataFlowSolver &solver)
-      : OpRewritePattern<bir::DeclareOp>(ctx), solver(solver) {}
+      : mlir::OpRewritePattern<bir::DeclareOp>(ctx), solver(solver) {}
 
-  LogicalResult
+  mlir::LogicalResult
   matchAndRewrite(bir::DeclareOp op,
                   mlir::PatternRewriter &rewriter) const override {
     const auto *state = 
@@ -32,7 +32,7 @@ struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
     else
       rewriter.replaceOpWithNewOp<bir::AllocStackOp>(op, refType);
 
-    return success();
+    return mlir::success();
   };
 
 private:
@@ -51,15 +51,15 @@ void belalang::bir::populateBelalangLowerDeclToMemoryPatterns(
 // -----------------------------------------------------------------------------
 
 struct BelalangLowerDeclToMemoryPass
-    : public impl::BelalangLowerDeclToMemoryPassBase<
+    : public mlir::impl::BelalangLowerDeclToMemoryPassBase<
           BelalangLowerDeclToMemoryPass> {
-  using impl::BelalangLowerDeclToMemoryPassBase<
+  using mlir::impl::BelalangLowerDeclToMemoryPassBase<
       BelalangLowerDeclToMemoryPass>::BelalangLowerDeclToMemoryPassBase;
 
   void runOnOperation() override {
-    SymbolTableCollection symbolTable;
+    mlir::SymbolTableCollection symbolTable;
 
-    DataFlowSolver solver;
+    mlir::DataFlowSolver solver;
     mlir::dataflow::loadBaselineAnalyses(solver);
     solver.load<EscapeAnalysis>(symbolTable);
     if (solver.initializeAndRun(getOperation()).failed())

--- a/lib/BIR/Transforms/LowerFuncExpr.cpp
+++ b/lib/BIR/Transforms/LowerFuncExpr.cpp
@@ -19,12 +19,12 @@ struct FuncExprOpLowering : public mlir::OpRewritePattern<FuncExprOp> {
                   mlir::PatternRewriter &rewriter) const override {
     // TODO: handle nested functions
     auto enclosingFunc = op->getParentOfType<FuncOp>();
-    auto module = op->getParentOfType<ModuleOp>();
+    auto module = op->getParentOfType<mlir::ModuleOp>();
     mlir::SymbolTable symTable(module);
-    FlatSymbolRefAttr symbolRef;
+    mlir::FlatSymbolRefAttr symbolRef;
 
     {
-      OpBuilder::InsertionGuard guard(rewriter);
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(module.getBody());
       std::string baseName = ("fn." + enclosingFunc.getName() + ".anon").str();
       auto fn = FuncOp::create(rewriter, op.getLoc(), baseName, op.getType());
@@ -36,7 +36,7 @@ struct FuncExprOpLowering : public mlir::OpRewritePattern<FuncExprOp> {
 
     auto attr = FnAttr::get(op.getContext(), op.getType(), symbolRef);
     rewriter.replaceOpWithNewOp<ConstantOp>(op, op.getType(), attr);
-    return success();
+    return mlir::success();
   }
 };
 } // namespace
@@ -51,8 +51,9 @@ void belalang::bir::populateBelalangLowerFuncExprPatterns(
 }
 
 struct BelalangLowerFuncExprPass
-    : public impl::BelalangLowerFuncExprPassBase<BelalangLowerFuncExprPass> {
-  using impl::BelalangLowerFuncExprPassBase<
+    : public mlir::impl::BelalangLowerFuncExprPassBase<
+          BelalangLowerFuncExprPass> {
+  using mlir::impl::BelalangLowerFuncExprPassBase<
       BelalangLowerFuncExprPass>::BelalangLowerFuncExprPassBase;
 
   /// Hoists AllocStackOps to the start of the current function body.

--- a/lib/BIR/Transforms/LowerToRuntimeCalls.cpp
+++ b/lib/BIR/Transforms/LowerToRuntimeCalls.cpp
@@ -114,8 +114,9 @@ void belalang::bir::populateBelalangLowerToRuntimeCallsPatterns(
 // -----------------------------------------------------------------------------
 
 struct BelalangLowerToRuntimeCallsPass
-    : public impl::BelalangLowerToRuntimeCallsPassBase<BelalangLowerToRuntimeCallsPass> {
-  using impl::BelalangLowerToRuntimeCallsPassBase<
+    : public mlir::impl::BelalangLowerToRuntimeCallsPassBase<
+          BelalangLowerToRuntimeCallsPass> {
+  using mlir::impl::BelalangLowerToRuntimeCallsPassBase<
       BelalangLowerToRuntimeCallsPass>::BelalangLowerToRuntimeCallsPassBase;
 
   void runOnOperation() override {


### PR DESCRIPTION
Having `using namespace` in BIR.h was confusing. This change removes the `using namespace` usage in BIR.h and replaces it with fully qualified types.