### PR TITLE
[bir][types] Implement DataLayout for BIR types

### DIFF
--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -89,6 +89,7 @@ td_library(
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
         "@llvm-project//mlir:LoopLikeInterfaceTdFiles",
+        "@llvm-project//mlir:DataLayoutInterfacesTdFiles",
     ],
 )
 

--- a/include/belalang/BIR/IR/BIR.h
+++ b/include/belalang/BIR/IR/BIR.h
@@ -6,6 +6,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/include/belalang/BIR/IR/BIRTypes.td
+++ b/include/belalang/BIR/IR/BIRTypes.td
@@ -2,6 +2,7 @@
 #define BELALANG_IR_TYPES_TD_
 
 include "belalang/BIR/IR/BIRDialect.td"
+include "mlir/Interfaces/DataLayoutInterfaces.td"
 
 class BIR_Type<string name, string typeMnemonic, list<Trait> traits = [],
                string baseCppClass = "::mlir::Type">
@@ -9,23 +10,34 @@ class BIR_Type<string name, string typeMnemonic, list<Trait> traits = [],
   let mnemonic = typeMnemonic;
 }
 
-def BIR_IntType : BIR_Type<"Int", "int"> {
+def BIR_IntType : BIR_Type<"Int", "int", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "Integer number type";
 }
 
-def BIR_FloatType : BIR_Type<"Float", "float"> {
+def BIR_FloatType : BIR_Type<"Float", "float", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "Floating-point number type";
 }
 
-def BIR_StringType : BIR_Type<"String", "string"> {
+def BIR_StringType : BIR_Type<"String", "string", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "String type";
 }
 
-def BIR_BoolType : BIR_Type<"Bool", "bool"> {
+def BIR_BoolType : BIR_Type<"Bool", "bool", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "Boolean type";
 }
 
-def BIR_StructType : BIR_Type<"Struct", "struct", [MutableType]> {
+def BIR_StructType : BIR_Type<"Struct", "struct", [
+  MutableType,
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "Struct type";
 
   let storageClass = "StructTypeStorage";
@@ -50,7 +62,9 @@ def BIR_ReferencableType : AnyTypeOf<[
   BIR_StructType
 ]>;
 
-def BIR_RefType : BIR_Type<"Ref", "ref"> {
+def BIR_RefType : BIR_Type<"Ref", "ref", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
   let summary = "Reference type";
 
   let parameters = (ins BIR_ReferencableType:$referent);

--- a/lib/BIR/IR/BIRTypes.cpp
+++ b/lib/BIR/IR/BIRTypes.cpp
@@ -1,7 +1,92 @@
 #include "belalang/BIR/IR/BIR.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 namespace belalang {
 namespace bir {
+
+// -----------------------------------------------------------------------------
+// IntType
+// -----------------------------------------------------------------------------
+
+llvm::TypeSize
+IntType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                           mlir::DataLayoutEntryListRef params) const {
+  return llvm::TypeSize::getFixed(64);
+}
+
+uint64_t IntType::getABIAlignment(const mlir::DataLayout &dl,
+                                  mlir::DataLayoutEntryListRef params) const {
+  return 8;
+}
+
+// -----------------------------------------------------------------------------
+// FloatType
+// -----------------------------------------------------------------------------
+
+llvm::TypeSize
+FloatType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                             mlir::DataLayoutEntryListRef params) const {
+  return llvm::TypeSize::getFixed(64);
+}
+
+uint64_t FloatType::getABIAlignment(const mlir::DataLayout &dl,
+                                    mlir::DataLayoutEntryListRef params) const {
+  return 8;
+}
+
+// -----------------------------------------------------------------------------
+// BoolType
+// -----------------------------------------------------------------------------
+
+llvm::TypeSize
+BoolType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                            mlir::DataLayoutEntryListRef params) const {
+  return llvm::TypeSize::getFixed(8);
+}
+
+uint64_t BoolType::getABIAlignment(const mlir::DataLayout &dl,
+                                   mlir::DataLayoutEntryListRef params) const {
+  return 1;
+}
+
+// -----------------------------------------------------------------------------
+// StringType
+// -----------------------------------------------------------------------------
+
+static mlir::Type getStringLLVMType(mlir::MLIRContext *ctx) {
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
+  auto lengthType = mlir::IntegerType::get(ctx, 64);
+  return mlir::LLVM::LLVMStructType::getLiteral(ctx, {ptrType, lengthType});
+}
+
+llvm::TypeSize
+StringType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                              mlir::DataLayoutEntryListRef params) const {
+  return dl.getTypeSizeInBits(getStringLLVMType(getContext()));
+}
+
+uint64_t
+StringType::getABIAlignment(const mlir::DataLayout &dl,
+                            mlir::DataLayoutEntryListRef params) const {
+  return dl.getTypeABIAlignment(getStringLLVMType(getContext()));
+}
+
+// -----------------------------------------------------------------------------
+// StructType
+// -----------------------------------------------------------------------------
+
+llvm::TypeSize
+RefType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                           mlir::DataLayoutEntryListRef params) const {
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
+  return dl.getTypeSizeInBits(ptrType);
+}
+
+uint64_t RefType::getABIAlignment(const mlir::DataLayout &dl,
+                                  mlir::DataLayoutEntryListRef params) const {
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
+  return dl.getTypeABIAlignment(ptrType);
+}
 
 mlir::Type StructType::parse(mlir::AsmParser &p) {
   const mlir::SMLoc loc = p.getCurrentLocation();
@@ -94,6 +179,38 @@ llvm::ArrayRef<mlir::Type> StructType::getMembers() const {
   return getImpl()->members;
 }
 mlir::StringAttr StructType::getName() const { return getImpl()->name; }
+
+llvm::TypeSize
+StructType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                              mlir::DataLayoutEntryListRef params) const {
+  unsigned stSize = 0;
+  uint64_t stAlign = 1;
+
+  for (mlir::Type ty : getMembers()) {
+    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
+
+    stSize = llvm::alignTo(stSize, tyAlign);
+    stSize += dl.getTypeSize(ty).getFixedValue();
+
+    stAlign = std::max(tyAlign, stAlign);
+  }
+
+  stSize = llvm::alignTo(stSize, stAlign);
+  return llvm::TypeSize::getFixed(stSize * 8); // We want in bits.
+}
+
+uint64_t
+StructType::getABIAlignment(const mlir::DataLayout &dl,
+                            mlir::DataLayoutEntryListRef params) const {
+  uint64_t stAlign = 1;
+
+  for (mlir::Type ty : getMembers()) {
+    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
+    stAlign = std::max(tyAlign, stAlign);
+  }
+
+  return stAlign;
+}
 
 } // namespace bir
 } // namespace belalang

--- a/lib/BIR/IR/BIRTypesTest.cpp
+++ b/lib/BIR/IR/BIRTypesTest.cpp
@@ -1,0 +1,150 @@
+#include "belalang/BIR/IR/BIR.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "gtest/gtest.h"
+
+// NOTE: Some of these tests assume 64-bit data layout which may not work on
+// 32-bit systems.
+
+namespace belalang {
+namespace bir {
+namespace {
+
+class BIRTypesTest : public ::testing::Test {
+protected:
+  mlir::MLIRContext context;
+  mlir::ModuleOp module;
+
+  BIRTypesTest()
+      : module(mlir::ModuleOp::create(mlir::UnknownLoc::get(&context))) {
+    context.getOrLoadDialect<BIRDialect>();
+    context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
+  }
+
+  mlir::DataLayout getDataLayout() {
+    return mlir::DataLayout::closest(module.getOperation());
+  }
+};
+
+TEST_F(BIRTypesTest, IntType) {
+  auto dl = getDataLayout();
+  auto ty = IntType::get(&context);
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, FloatType) {
+  auto dl = getDataLayout();
+  auto ty = FloatType::get(&context);
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, BoolType) {
+  auto dl = getDataLayout();
+  auto ty = BoolType::get(&context);
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 8);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+}
+
+TEST_F(BIRTypesTest, StringType) {
+  auto dl = getDataLayout();
+  auto ty = StringType::get(&context);
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, RefTypeMatchesLLVMPointer) {
+  auto dl = getDataLayout();
+  auto ty = RefType::get(&context, IntType::get(&context));
+  auto llvmPtr = mlir::LLVM::LLVMPointerType::get(&context);
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty), dl.getTypeSizeInBits(llvmPtr));
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), dl.getTypeABIAlignment(llvmPtr));
+}
+
+TEST_F(BIRTypesTest, EmptyStructType) {
+  auto dl = getDataLayout();
+  auto ty =
+      StructType::get(&context, {}, mlir::StringAttr::get(&context, "Empty"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 0);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+}
+
+TEST_F(BIRTypesTest, StructTypeWithLeadingPadding) {
+  auto dl = getDataLayout();
+  auto ty = StructType::get(&context,
+                            {BoolType::get(&context), IntType::get(&context)},
+                            mlir::StringAttr::get(&context, "BoolInt"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, StructTypeWithTrailingPadding) {
+  auto dl = getDataLayout();
+  auto ty = StructType::get(&context,
+                            {IntType::get(&context), BoolType::get(&context)},
+                            mlir::StringAttr::get(&context, "IntBool"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, StructTypeWithOnlyByteAlignedMembers) {
+  auto dl = getDataLayout();
+  auto ty = StructType::get(&context,
+                            {BoolType::get(&context), BoolType::get(&context),
+                             BoolType::get(&context)},
+                            mlir::StringAttr::get(&context, "Bools"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 24);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+}
+
+TEST_F(BIRTypesTest, StructTypeWithStringAndBool) {
+  auto dl = getDataLayout();
+  auto ty = StructType::get(
+      &context, {StringType::get(&context), BoolType::get(&context)},
+      mlir::StringAttr::get(&context, "StringBool"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 192);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, StructTypeWithReferenceAndBool) {
+  auto dl = getDataLayout();
+  auto ty = StructType::get(
+      &context,
+      {RefType::get(&context, IntType::get(&context)),
+       BoolType::get(&context)},
+      mlir::StringAttr::get(&context, "RefBool"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, NestedStructType) {
+  auto dl = getDataLayout();
+  auto inner = StructType::get(
+      &context, {BoolType::get(&context), IntType::get(&context)},
+      mlir::StringAttr::get(&context, "Inner"));
+  auto outer = StructType::get(
+      &context, {BoolType::get(&context), inner, BoolType::get(&context)},
+      mlir::StringAttr::get(&context, "Outer"));
+
+  EXPECT_EQ(dl.getTypeSizeInBits(outer).getFixedValue(), 256);
+  EXPECT_EQ(dl.getTypeABIAlignment(outer), 8);
+}
+
+} // namespace
+} // namespace bir
+} // namespace belalang

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_rust//rust:defs.bzl", "rust_static_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -36,7 +36,10 @@ cc_library(
 
 cc_library(
     name = "BIR",
-    srcs = glob(["BIR/**/*.cpp"]),
+    srcs = glob(
+        ["BIR/**/*.cpp"],
+        exclude = ["BIR/**/*Test.cpp"],
+    ),
     deps = [
         "//include:BIR",
         "@llvm-project//mlir:Pass",
@@ -49,6 +52,19 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
     ],
 )
+
+[
+    cc_test(
+        name = test[:-4].replace("/", "_"),
+        srcs = [test],
+        deps = [
+            ":BIR",
+            "//include:BIR",
+            "@googletest//:gtest_main",
+        ],
+    )
+    for test in glob(["BIR/**/*Test.cpp"])
+]
 
 # ------------------------------------------------------------------------------
 # BIRGen


### PR DESCRIPTION
Implements DataLayoutTypeInterface for Int, Float, String, Bool, Struct, and Ref. The implementation took a lot of inspirations from ClangIR and its types.