### PR TITLE
[diag] Fix Rust warnings on unsafe usage

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -118,6 +118,7 @@ cc_library(
 
 rust_static_library(
     name = "Diag-rs",
+    crate_name = "belalang_diag",
     srcs = ["Diag/diag.rs"],
     deps = [
         "@crates//:annotate-snippets",

--- a/lib/Diag/diag.rs
+++ b/lib/Diag/diag.rs
@@ -29,6 +29,13 @@ pub struct FFIDiagnostic {
     pub labels_len: usize,
 }
 
+/// # Safety
+///
+/// This function is unsafe because:
+/// - All the pointers must be valid for the duration of the call
+/// - The lengths must match the data the pointers point at
+/// - `diag.message` and `label.message` must be NUL terminated
+/// - `source_text` and `source_file` must be valid UTF-8
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn belalang_print_diagnostic(
     diag: *const FFIDiagnostic,
@@ -38,16 +45,18 @@ pub unsafe extern "C" fn belalang_print_diagnostic(
     source_file_len: usize,
     use_color: bool,
 ) {
-    let source_text = std::str::from_utf8_unchecked(std::slice::from_raw_parts(source_text, source_text_len));
-    let source_file = std::str::from_utf8_unchecked(std::slice::from_raw_parts(source_file, source_file_len));
+    let source_text_bytes = unsafe { std::slice::from_raw_parts(source_text, source_text_len) };
+    let source_file_bytes = unsafe { std::slice::from_raw_parts(source_file, source_file_len) };
+    let source_text = unsafe { std::str::from_utf8_unchecked(source_text_bytes) };
+    let source_file = unsafe { std::str::from_utf8_unchecked(source_file_bytes) };
 
-    let diag = &*diag;
-    let message = CStr::from_ptr(diag.message).to_str().unwrap();
-    let labels_slice = std::slice::from_raw_parts(diag.labels, diag.labels_len);
+    let diag = unsafe { &*diag };
+    let message = unsafe { CStr::from_ptr(diag.message) }.to_str().unwrap();
+    let labels_slice = unsafe { std::slice::from_raw_parts(diag.labels, diag.labels_len) };
 
     let mut annotations = Vec::new();
     for label in labels_slice {
-        let label_msg = CStr::from_ptr(label.message).to_str().unwrap();
+        let label_msg = unsafe { CStr::from_ptr(label.message) }.to_str().unwrap();
         let span = label.span_start..label.span_end;
         let kind = if label.is_primary {
             AnnotationKind::Primary


### PR DESCRIPTION
Closes #312

Wraps each unsafe operation in `belalang_print_diagnostic` in its own
unsafe block, which edition 2024 now requires. Also adds the `# Safety`
section clippy asks for and sets `crate_name` so the crate is not named
`Diag_rs` after the target.
