### PR TITLE
[bir] Implement DCE pass

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -29,6 +29,7 @@ def BIR_AnyType : AnyTypeOf<[
 
 def BIR_ConstantOp : BIR_Op<"constant", [
   AllTypesMatch<["value", "result"]>,
+  Pure,
 ]> {
   let summary = "constant";
 
@@ -46,7 +47,11 @@ def BIR_ConstantOp : BIR_Op<"constant", [
   let hasVerifier = 1;
 }
 
-def BIR_AddOp : BIR_Op<"add", [SameTypeOperands, SameOperandsAndResultType]> {
+def BIR_AddOp : BIR_Op<"add", [
+  SameTypeOperands,
+  SameOperandsAndResultType,
+  Pure
+]> {
   let summary = "add";
 
   let description = [{
@@ -63,7 +68,11 @@ def BIR_AddOp : BIR_Op<"add", [SameTypeOperands, SameOperandsAndResultType]> {
   let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_SubOp : BIR_Op<"sub", [SameTypeOperands, SameOperandsAndResultType]> {
+def BIR_SubOp : BIR_Op<"sub", [
+  SameTypeOperands,
+  SameOperandsAndResultType,
+  Pure
+]> {
   let summary = "sub";
 
   let description = [{
@@ -80,7 +89,11 @@ def BIR_SubOp : BIR_Op<"sub", [SameTypeOperands, SameOperandsAndResultType]> {
   let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_MulOp : BIR_Op<"mul", [SameTypeOperands, SameOperandsAndResultType]> {
+def BIR_MulOp : BIR_Op<"mul", [
+  SameTypeOperands,
+  SameOperandsAndResultType,
+  Pure
+]> {
   let summary = "mul";
 
   let description = [{
@@ -97,7 +110,11 @@ def BIR_MulOp : BIR_Op<"mul", [SameTypeOperands, SameOperandsAndResultType]> {
   let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_DivOp : BIR_Op<"div", [SameTypeOperands, SameOperandsAndResultType]> {
+def BIR_DivOp : BIR_Op<"div", [
+  SameTypeOperands,
+  SameOperandsAndResultType,
+  Pure
+]> {
   let summary = "div";
 
   let description = [{
@@ -114,7 +131,11 @@ def BIR_DivOp : BIR_Op<"div", [SameTypeOperands, SameOperandsAndResultType]> {
   let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_ModOp : BIR_Op<"mod", [SameTypeOperands, SameOperandsAndResultType]> {
+def BIR_ModOp : BIR_Op<"mod", [
+  SameTypeOperands,
+  SameOperandsAndResultType,
+  Pure
+]> {
   let summary = "mod";
 
   let description = [{
@@ -131,7 +152,7 @@ def BIR_ModOp : BIR_Op<"mod", [SameTypeOperands, SameOperandsAndResultType]> {
   let assemblyFormat = "$lhs `,` $rhs `:` type($lhs) attr-dict";
 }
 
-def BIR_AndOp : BIR_Op<"and"> {
+def BIR_AndOp : BIR_Op<"and", [Pure]> {
   let summary = "and";
 
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
@@ -141,7 +162,7 @@ def BIR_AndOp : BIR_Op<"and"> {
       "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
 }
 
-def BIR_OrOp : BIR_Op<"or"> {
+def BIR_OrOp : BIR_Op<"or", [Pure]> {
   let summary = "or";
 
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
@@ -151,7 +172,7 @@ def BIR_OrOp : BIR_Op<"or"> {
       "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
 }
 
-def BIR_XorOp : BIR_Op<"xor"> {
+def BIR_XorOp : BIR_Op<"xor", [Pure]> {
   let summary = "xor";
 
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
@@ -161,7 +182,7 @@ def BIR_XorOp : BIR_Op<"xor"> {
       "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
 }
 
-def BIR_ShlOp : BIR_Op<"shl"> {
+def BIR_ShlOp : BIR_Op<"shl", [Pure]> {
   let summary = "shl";
 
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
@@ -171,7 +192,7 @@ def BIR_ShlOp : BIR_Op<"shl"> {
       "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
 }
 
-def BIR_ShrOp : BIR_Op<"shr"> {
+def BIR_ShrOp : BIR_Op<"shr", [Pure]> {
   let summary = "shr";
 
   let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
@@ -498,7 +519,7 @@ def BIR_CmpOp : BIR_Op<"cmp", [
 
 }
 
-def BIR_GetMemberOp : BIR_Op<"get_member"> {
+def BIR_GetMemberOp : BIR_Op<"get_member", [Pure]> {
   let arguments = (ins
     BIR_RefType:$addr, // TODO: maybe make a pointer type?
     StrAttr:$name,

--- a/lib/BIR/Pipelines.cpp
+++ b/lib/BIR/Pipelines.cpp
@@ -1,4 +1,5 @@
 #include "belalang/BIR/Passes.h"
+#include "mlir/Transforms/Passes.h"
 
 namespace belalang {
 namespace bir {
@@ -14,6 +15,8 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangOptimizeStructLayoutPass());
   pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
+  pm.addPass(mlir::createTrivialDeadCodeEliminationPass());
+  pm.addPass(mlir::createSymbolDCEPass());
   pm.addPass(createBelalangInsertStackMapsPass());
 }
 

--- a/lib/BIR/Transforms/LowerFuncExpr.cpp
+++ b/lib/BIR/Transforms/LowerFuncExpr.cpp
@@ -28,6 +28,7 @@ struct FuncExprOpLowering : public mlir::OpRewritePattern<FuncExprOp> {
       rewriter.setInsertionPointToStart(module.getBody());
       std::string baseName = ("fn." + enclosingFunc.getName() + ".anon").str();
       auto fn = FuncOp::create(rewriter, op.getLoc(), baseName, op.getType());
+      fn.setPrivate();
       rewriter.inlineRegionBefore(op.getBody(), fn.getBody(),
                                   fn.getBody().end());
       auto finalName = symTable.insert(fn);

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -50,6 +50,7 @@ cc_library(
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:ControlFlowToLLVM",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/tests/BIR/Transforms/BIRToLLVM/cf.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/cf.mlir
@@ -22,7 +22,6 @@ bir.func @main() -> !bir.int {
 // CHECK-LABEL:  llvm.func @main() {
 // CHECK-NEXT:     llvm.br ^bb1
 // CHECK-NEXT:   ^bb1:  // pred: ^bb0
-// CHECK-NEXT:     %[[VAL:.*]] = llvm.mlir.constant(42 : i64) : i64
 // CHECK-NEXT:     llvm.br ^bb2
 // CHECK-NEXT:   ^bb2:  // pred: ^bb1
 // CHECK-NEXT:     llvm.return

--- a/tests/BIR/Transforms/DCE/BUILD.bazel
+++ b/tests/BIR/Transforms/DCE/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/DCE/pipeline.mlir
+++ b/tests/BIR/Transforms/DCE/pipeline.mlir
@@ -1,0 +1,42 @@
+// RUN: %bir-opt --split-input-file --bir-lowering-pipeline %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @drops_dead_pure_work
+// CHECK-NOT: bir.add
+// CHECK-NOT: bir.mul
+// CHECK: bir.safepoint 0
+// CHECK-NEXT: %[[HEAP:.*]] = bir.alloc_heap : !bir.ref<!bir.int>
+// CHECK: bir.return
+bir.func @drops_dead_pure_work() {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  %1 = bir.constant #bir.int<2> : !bir.int
+  %2 = bir.add %0, %1 : !bir.int
+  %3 = bir.mul %2, %1 : !bir.int
+  %4 = bir.alloc_heap : !bir.ref<!bir.int>
+  bir.return
+}
+
+// -----
+
+// CHECK-NOT: @fn.drops_unused_func_expr.anon
+// CHECK-LABEL: bir.func @drops_unused_func_expr
+// CHECK-NEXT: bir.return
+bir.func @drops_unused_func_expr() {
+  %0 = bir.func_expr : () -> () {
+    bir.return
+  }
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func private @fn.keeps_referenced_func_expr.anon
+// CHECK-LABEL: bir.func @keeps_referenced_func_expr
+// CHECK: bir.constant #bir.fn<@fn.keeps_referenced_func_expr.anon> : () -> ()
+// CHECK: bir.call_indirect
+bir.func @keeps_referenced_func_expr() {
+  %0 = bir.func_expr : () -> () {
+    bir.return
+  }
+  bir.call_indirect %0() : () -> ()
+  bir.return
+}

--- a/tests/BIR/Transforms/DCE/symbol-dce.mlir
+++ b/tests/BIR/Transforms/DCE/symbol-dce.mlir
@@ -1,0 +1,25 @@
+// RUN: %bir-opt --split-input-file --symbol-dce %s | %FileCheck %s
+
+// CHECK-NOT: @dead
+bir.func private @dead() {
+  bir.return
+}
+
+// CHECK-LABEL: bir.func @main
+bir.func @main() {
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func private @kept
+// CHECK-LABEL: bir.func @main
+// CHECK: bir.constant #bir.fn<@kept> : () -> ()
+bir.func private @kept() {
+  bir.return
+}
+
+bir.func @main() {
+  %0 = bir.constant #bir.fn<@kept> : () -> ()
+  bir.return
+}

--- a/tests/BIR/Transforms/DCE/trivial-dce.mlir
+++ b/tests/BIR/Transforms/DCE/trivial-dce.mlir
@@ -1,0 +1,89 @@
+// RUN: %bir-opt --split-input-file --trivial-dce %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @unused_arithmetic
+// CHECK-NEXT: bir.return
+bir.func @unused_arithmetic() {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  %1 = bir.constant #bir.int<2> : !bir.int
+  %2 = bir.add %0, %1 : !bir.int
+  %3 = bir.mul %2, %1 : !bir.int
+  %4 = bir.sub %3, %0 : !bir.int
+  %5 = bir.div %4, %1 : !bir.int
+  %6 = bir.mod %5, %1 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @unused_constant
+// CHECK-NEXT: bir.return
+bir.func @unused_constant() {
+  %0 = bir.constant #bir.int<42> : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @unused_get_member
+// CHECK-NEXT: %[[REF:.*]] = bir.alloc_stack : !bir.ref<!struct_Point>
+// CHECK-NEXT: bir.return
+bir.func @unused_get_member() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.struct<"Point", {!bir.int, !bir.int}>>
+  %1 = bir.get_member %0[0] {name = "x"} : !bir.ref<!bir.struct<"Point", {!bir.int, !bir.int}>> -> !bir.ref<!bir.int>
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @retain_effectful_ops
+// CHECK: %[[ZERO:.*]] = bir.constant #bir.int<0> : !bir.int
+// CHECK: %[[STACK:.*]] = bir.alloc_stack : !bir.ref<!bir.int>
+// CHECK: bir.store %[[ZERO]] to %[[STACK]] : !bir.int to !bir.ref<!bir.int>
+// CHECK: bir.load %[[STACK]] : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK: bir.print %[[ZERO]] : !bir.int
+// CHECK: bir.call @callee(%[[ZERO]]) : (!bir.int) -> ()
+// CHECK: bir.safepoint 0(%[[STACK]] : !bir.ref<!bir.int>)
+// CHECK: %[[HEAP:.*]] = bir.alloc_heap : !bir.ref<!bir.int>
+// CHECK: bir.return
+bir.func @callee(!bir.int)
+
+bir.func @retain_effectful_ops() {
+  %0 = bir.constant #bir.int<0> : !bir.int
+  %1 = bir.alloc_stack : !bir.ref<!bir.int>
+  bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %0 : !bir.int
+  bir.call @callee(%0) : (!bir.int) -> ()
+  bir.safepoint 0(%1 : !bir.ref<!bir.int>)
+  %3 = bir.alloc_heap : !bir.ref<!bir.int>
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @unused_bitwise_and_cmp
+// CHECK-NEXT: bir.return
+bir.func @unused_bitwise_and_cmp() {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  %1 = bir.constant #bir.int<2> : !bir.int
+  %2 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int
+  %3 = bir.or %2, %1 : (!bir.int, !bir.int) -> !bir.int
+  %4 = bir.xor %3, %0 : (!bir.int, !bir.int) -> !bir.int
+  %5 = bir.shl %4, %0 : (!bir.int, !bir.int) -> !bir.int
+  %6 = bir.shr %5, %0 : (!bir.int, !bir.int) -> !bir.int
+  %7 = bir.cmp eq %6, %1 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @unreachable_blocks
+// CHECK-NEXT: bir.return
+// CHECK-NEXT: }
+bir.func @unreachable_blocks() {
+  bir.return
+^dead:
+  %0 = bir.constant #bir.int<1> : !bir.int
+  bir.print %0 : !bir.int
+  bir.return
+}

--- a/tests/BIR/Transforms/LowerFuncExpr/lower-func-expr.mlir
+++ b/tests/BIR/Transforms/LowerFuncExpr/lower-func-expr.mlir
@@ -1,11 +1,10 @@
 // RUN: %bir-opt --split-input-file --bir-lower-func-expr %s | %FileCheck %s
 
-// CHECK-LABEL: bir.func @fn.explicit_return.anon
+// CHECK-LABEL: bir.func private @fn.explicit_return.anon
 // CHECK: %{{.*}} = bir.constant #bir.int<42> : !bir.int
 // CHECK: bir.return
 
 // CHECK-LABEL: bir.func @explicit_return
-// CHECK-NEXT:   %{{.*}} = bir.constant #bir.fn<@fn.explicit_return.anon> : () -> !bir.int
 // CHECK-NEXT:   bir.return
 bir.func @explicit_return() {
   %0 = bir.func_expr : () -> !bir.int {
@@ -17,11 +16,10 @@ bir.func @explicit_return() {
 
 // -----
 
-// CHECK-LABEL: bir.func @fn.with_args.anon
+// CHECK-LABEL: bir.func private @fn.with_args.anon
 // CHECK: bir.return
 
 // CHECK-LABEL: bir.func @with_args
-// CHECK-NEXT:   %{{.*}} = bir.constant #bir.fn<@fn.with_args.anon> : (!bir.int) -> !bir.int
 // CHECK-NEXT:   bir.return
 bir.func @with_args() {
   %0 = bir.func_expr : (!bir.int) -> !bir.int {
@@ -33,11 +31,10 @@ bir.func @with_args() {
 
 // -----
 
-// CHECK-LABEL: bir.func @fn.void_return.anon
+// CHECK-LABEL: bir.func private @fn.void_return.anon
 // CHECK: bir.return
 
 // CHECK-LABEL: bir.func @void_return
-// CHECK-NEXT:   %{{.*}} = bir.constant #bir.fn<@fn.void_return.anon> : () -> ()
 // CHECK-NEXT:   bir.return
 bir.func @void_return() {
   %0 = bir.func_expr : () -> () {
@@ -48,15 +45,13 @@ bir.func @void_return() {
 
 // -----
 
-// CHECK-LABEL: bir.func @fn.void_return.anon_0
+// CHECK-LABEL: bir.func private @fn.void_return.anon_0
 // CHECK: bir.return
 
-// CHECK-LABEL: bir.func @fn.void_return.anon
+// CHECK-LABEL: bir.func private @fn.void_return.anon
 // CHECK: bir.return
 
 // CHECK-LABEL: bir.func @void_return
-// CHECK-NEXT:   %{{.*}} = bir.constant #bir.fn<@fn.void_return.anon_0> : () -> ()
-// CHECK-NEXT:   %{{.*}} = bir.constant #bir.fn<@fn.void_return.anon> : () -> ()
 // CHECK-NEXT:   bir.return
 bir.func @void_return() {
   %0 = bir.func_expr : () -> () {

--- a/tools/bir-opt/bir-opt.cpp
+++ b/tools/bir-opt/bir-opt.cpp
@@ -1,6 +1,7 @@
 #include "belalang/BIR/IR/BIR.h"
 #include "belalang/BIR/Passes.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "mlir/Transforms/Passes.h"
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
@@ -9,6 +10,7 @@ int main(int argc, char **argv) {
 
   belalang::bir::registerPasses();
   belalang::bir::registerBIRPipelines();
+  mlir::registerTransformsPasses();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "Belalang IR analysis and optimization tool\n", registry));


### PR DESCRIPTION
Closes #351 

- Adds the DCE passes in MLIR to BIR pipeline by using MLIR builtin trivial DCE and symbol DCE by using MLIR's Pure interface.
- Also makes the function generated by function expressions to private to help with symbol DCE.
- Also fixes some failing passes due to the implemented DCE.