### PR TITLE
[bir] Implement VerifyLoweredForm pass

### DIFF
--- a/include/belalang/BIR/Passes.td
+++ b/include/belalang/BIR/Passes.td
@@ -29,6 +29,12 @@ def BelalangInsertStackMapsPass : Pass<"bir-insert-stackmaps"> {
   let dependentDialects = ["::belalang::bir::BIRDialect"];
 }
 
+def BelalangVerifyLoweredFormPass : Pass<"bir-verify-lowered-form"> {
+  let summary = "verify BIR contains only ops expected after lowering";
+  let dependentDialects = ["::belalang::bir::BIRDialect",
+                           "::mlir::cf::ControlFlowDialect"];
+}
+
 def BelalangOptimizeStructLayoutPass : Pass<"bir-optimize-struct-layout"> {
   let summary = "compute compact physical layouts for BIR structs";
   let dependentDialects = ["::belalang::bir::BIRDialect"];

--- a/lib/BIR/Pipelines.cpp
+++ b/lib/BIR/Pipelines.cpp
@@ -15,6 +15,7 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
   pm.addPass(createBelalangInsertStackMapsPass());
+  pm.addPass(createBelalangVerifyLoweredFormPass());
 }
 
 void registerBIRPipelines() {

--- a/lib/BIR/Transforms/VerifyLoweredForm.cpp
+++ b/lib/BIR/Transforms/VerifyLoweredForm.cpp
@@ -1,0 +1,46 @@
+#include "belalang/BIR/IR/BIR.h"
+#include "belalang/BIR/Passes.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_BELALANGVERIFYLOWEREDFORMPASS
+#include "belalang/BIR/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+using namespace belalang;
+using namespace belalang::bir;
+
+bool isUnexpectedAfterLowering(mlir::Operation *op) {
+  return mlir::isa<bir::DeclareOp, bir::ScopeOp, bir::IfOp, bir::WhileOp,
+                   bir::BreakOp, bir::ContinueOp, bir::ConditionOp,
+                   bir::YieldOp, bir::FuncExprOp, bir::PrintOp>(op);
+}
+
+struct BelalangVerifyLoweredFormPass
+    : public mlir::impl::BelalangVerifyLoweredFormPassBase<
+          BelalangVerifyLoweredFormPass> {
+  using mlir::impl::BelalangVerifyLoweredFormPassBase<
+      BelalangVerifyLoweredFormPass>::BelalangVerifyLoweredFormPassBase;
+
+  void runOnOperation() override {
+    auto result = getOperation()->walk<mlir::WalkOrder::PreOrder>(
+        [&](mlir::Operation *op) {
+          if (!isUnexpectedAfterLowering(op))
+            return mlir::WalkResult::advance();
+
+          op->emitOpError()
+              << "unexpected high-level BIR operation after lowering pipeline";
+          return mlir::WalkResult::interrupt();
+        });
+
+    if (result.wasInterrupted())
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+belalang::bir::createBelalangVerifyLoweredFormPass() {
+  return std::make_unique<BelalangVerifyLoweredFormPass>();
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/BUILD.bazel
+++ b/tests/BIR/Transforms/VerifyLoweredForm/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/VerifyLoweredForm/error-declare.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/error-declare.mlir
@@ -1,0 +1,7 @@
+// RUN: %not %bir-opt --split-input-file --bir-verify-lowered-form %s 2>&1 | %FileCheck %s
+
+// CHECK: 'bir.declare' op unexpected high-level BIR operation after lowering pipeline
+bir.func @has_declare() {
+  %0 = bir.declare "x" : !bir.ref<!bir.int>
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/error-func-expr.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/error-func-expr.mlir
@@ -1,0 +1,9 @@
+// RUN: %not %bir-opt --split-input-file --bir-verify-lowered-form %s 2>&1 | %FileCheck %s
+
+// CHECK: 'bir.func_expr' op unexpected high-level BIR operation after lowering pipeline
+bir.func @has_func_expr() {
+  %0 = bir.func_expr : () -> () {
+    bir.return
+  }
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/error-if.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/error-if.mlir
@@ -1,0 +1,10 @@
+// RUN: %not %bir-opt --split-input-file --bir-verify-lowered-form %s 2>&1 | %FileCheck %s
+
+// CHECK: 'bir.if' op unexpected high-level BIR operation after lowering pipeline
+bir.func @has_if() {
+  %0 = bir.constant #bir.bool<true> : !bir.bool
+  bir.if %0 {
+    bir.yield
+  }
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/error-print.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/error-print.mlir
@@ -1,0 +1,8 @@
+// RUN: %not %bir-opt --split-input-file --bir-verify-lowered-form %s 2>&1 | %FileCheck %s
+
+// CHECK: 'bir.print' op unexpected high-level BIR operation after lowering pipeline
+bir.func @has_print() {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  bir.print %0 : !bir.int
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/error-while.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/error-while.mlir
@@ -1,0 +1,12 @@
+// RUN: %not %bir-opt --split-input-file --bir-verify-lowered-form %s 2>&1 | %FileCheck %s
+
+// CHECK: 'bir.while' op unexpected high-level BIR operation after lowering pipeline
+bir.func @has_while() {
+  bir.while {
+    %0 = bir.constant #bir.bool<false> : !bir.bool
+    bir.condition %0
+  } do {
+    bir.yield
+  }
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/pipeline.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/pipeline.mlir
@@ -1,0 +1,14 @@
+// RUN: %bir-opt --split-input-file --bir-lowering-pipeline %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @pipeline
+// CHECK-NOT: bir.declare
+// CHECK-NOT: bir.print
+// CHECK-NOT: bir.if
+bir.func @pipeline() {
+  %0 = bir.constant #bir.int<1> : !bir.int
+  %1 = bir.declare "x" : !bir.ref<!bir.int>
+  bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %2 : !bir.int
+  bir.return
+}

--- a/tests/BIR/Transforms/VerifyLoweredForm/valid.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/valid.mlir
@@ -1,0 +1,10 @@
+// RUN: %bir-opt --split-input-file --bir-verify-lowered-form %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @lowered
+bir.func @lowered() -> !bir.int {
+  %0 = bir.constant #bir.int<42> : !bir.int
+  %1 = bir.alloc_stack : !bir.ref<!bir.int>
+  bir.store %0 to %1 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %1 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.return %2 : !bir.int
+}


### PR DESCRIPTION
Closes #350 

This change implements a new pass named `VerifyLoweredForm`. The pass verifies if the BIR is ready for lowering to LLVM by disallowing for higher level ops before going to `BIRToLLVM` conversion.