### PR TITLE
[bir][Mem2Reg] Initial implementation of Mem2Reg pass

### DIFF
--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -68,6 +68,7 @@ cc_library(
         ":BelalangPassIncGen",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:MemorySlotInterfaces",
     ],
 )
 
@@ -90,6 +91,7 @@ td_library(
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
         "@llvm-project//mlir:LoopLikeInterfaceTdFiles",
         "@llvm-project//mlir:DataLayoutInterfacesTdFiles",
+        "@llvm-project//mlir:MemorySlotInterfacesTdFiles",
     ],
 )
 

--- a/include/belalang/BIR/IR/BIR.h
+++ b/include/belalang/BIR/IR/BIR.h
@@ -9,6 +9,7 @@
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -14,6 +14,7 @@ include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/MemorySlotInterfaces.td"
 
 class BIR_Op<string mnemonic, list<Trait> traits = []>
     : Op<BIR_Dialect, mnemonic, traits> {}
@@ -356,7 +357,9 @@ def BIR_DeclareOp : BIR_Op<"declare"> {
   let assemblyFormat = "$name attr-dict `:` qualified(type($result))";
 }
 
-def BIR_StoreOp : BIR_Op<"store"> {
+def BIR_StoreOp : BIR_Op<"store", [
+  DeclareOpInterfaceMethods<PromotableMemOpInterface>
+]> {
   let summary = "store";
 
   let arguments = (ins BIR_AnyType:$src, BIR_RefType:$dest);
@@ -364,7 +367,9 @@ def BIR_StoreOp : BIR_Op<"store"> {
   let assemblyFormat = "$src `to` $dest attr-dict `:` type($src) `to` qualified(type($dest))";
 }
 
-def BIR_LoadOp : BIR_Op<"load"> {
+def BIR_LoadOp : BIR_Op<"load", [
+  DeclareOpInterfaceMethods<PromotableMemOpInterface>
+]> {
   let summary = "load";
 
   let arguments = (ins BIR_RefType:$ref);
@@ -397,7 +402,7 @@ def BIR_YieldOp : BIR_Op<"yield", [
 }
 
 def BIR_IfOp : BIR_Op<"if", [
-  NoRegionArguments,
+  NoRegionArguments
 ]> {
   let summary = "if";
 
@@ -548,7 +553,9 @@ def BIR_AllocHeapOp : BIR_Op<"alloc_heap"> {
   }];
 }
 
-def BIR_AllocStackOp : BIR_Op<"alloc_stack"> {
+def BIR_AllocStackOp : BIR_Op<"alloc_stack", [
+  DeclareOpInterfaceMethods<PromotableAllocationOpInterface>
+]> {
   let arguments = (ins);
 
   let results = (outs

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -5,6 +5,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
 #include "mlir/Support/LLVM.h"
 
 #define GET_OP_CLASSES
@@ -13,6 +14,39 @@
 
 namespace belalang {
 namespace bir {
+
+namespace {
+
+mlir::TypedAttr getDefaultAttr(mlir::MLIRContext *ctx, mlir::Type type) {
+  if (mlir::isa<bir::IntType>(type))
+    return bir::IntegerAttr::get(ctx, type, llvm::APInt(64, 0));
+
+  if (mlir::isa<bir::FloatType>(type))
+    return bir::FloatAttr::get(ctx, type, llvm::APFloat(0.0));
+
+  if (mlir::isa<bir::StringType>(type))
+    return bir::StringAttr::get(ctx, type, "");
+
+  if (mlir::isa<bir::BoolType>(type))
+    return bir::BoolAttr::get(ctx, type, false);
+
+  if (auto structType = mlir::dyn_cast<bir::StructType>(type)) {
+    llvm::SmallVector<mlir::Attribute> members;
+    llvm::SmallVector<mlir::Type> memberTypes;
+    for (mlir::Type memberType : structType.getMembers()) {
+      mlir::TypedAttr memberAttr = getDefaultAttr(ctx, memberType);
+      if (!memberAttr)
+        return {};
+      members.push_back(memberAttr);
+      memberTypes.push_back(memberType);
+    }
+    return bir::StructAttr::get(ctx, type, members, memberTypes);
+  }
+
+  return {};
+}
+
+} // namespace
 
 // -----------------------------------------------------------------------------
 // ConstantOp
@@ -292,6 +326,114 @@ mlir::LogicalResult bir::ConditionOp::verify() {
   if (!mlir::isa<LoopOpInterface>(getOperation()->getParentOp()))
     return emitOpError("must be within a conditional region");
   return mlir::success();
+}
+
+// -----------------------------------------------------------------------------
+// AllocStackOp: PromotableAllocationOpInterface
+// -----------------------------------------------------------------------------
+
+llvm::SmallVector<mlir::MemorySlot> AllocStackOp::getPromotableSlots() {
+  // Single-element stack allocation is promoted to a scalar SSA value.
+  auto refType = mlir::cast<bir::RefType>(getType());
+  return {mlir::MemorySlot{getResult(), refType.getReferent()}};
+}
+
+mlir::Value AllocStackOp::getDefaultValue(const mlir::MemorySlot &slot,
+                                          mlir::OpBuilder &builder) {
+  mlir::TypedAttr attr = getDefaultAttr(getContext(), slot.elemType);
+  if (!attr)
+    return {};
+  return bir::ConstantOp::create(builder, getLoc(), slot.elemType, attr);
+}
+
+void AllocStackOp::handleBlockArgument(const mlir::MemorySlot &slot,
+                                       mlir::BlockArgument argument,
+                                       mlir::OpBuilder &builder) {}
+
+std::optional<mlir::PromotableAllocationOpInterface>
+AllocStackOp::handlePromotionComplete(const mlir::MemorySlot &slot,
+                                      mlir::Value defaultValue,
+                                      mlir::OpBuilder &builder) {
+  if (defaultValue && defaultValue.use_empty())
+    defaultValue.getDefiningOp()->erase();
+  this->erase();
+  return std::nullopt;
+}
+
+// -----------------------------------------------------------------------------
+// LoadOp: PromotableMemOpInterface
+// -----------------------------------------------------------------------------
+
+bool LoadOp::loadsFrom(const mlir::MemorySlot &slot) {
+  return getRef() == slot.ptr;
+}
+
+bool LoadOp::storesTo(const mlir::MemorySlot &slot) { return false; }
+
+mlir::Value LoadOp::getStored(const mlir::MemorySlot &slot,
+                              mlir::OpBuilder &builder, mlir::Value reachingDef,
+                              const mlir::DataLayout &dataLayout) {
+  llvm_unreachable("getStored should not be called on LoadOp");
+}
+
+bool LoadOp::canUsesBeRemoved(
+    const mlir::MemorySlot &slot,
+    const llvm::SmallPtrSetImpl<mlir::OpOperand *> &blockingUses,
+    llvm::SmallVectorImpl<mlir::OpOperand *> &newBlockingUses,
+    const mlir::DataLayout &dataLayout) {
+  if (blockingUses.size() != 1)
+    return false;
+
+  mlir::Value blockingUse = (*blockingUses.begin())->get();
+  return blockingUse == slot.ptr && getRef() == slot.ptr &&
+         getResult().getType() == slot.elemType;
+}
+
+mlir::DeletionKind LoadOp::removeBlockingUses(
+    const mlir::MemorySlot &slot,
+    const llvm::SmallPtrSetImpl<mlir::OpOperand *> &blockingUses,
+    mlir::OpBuilder &builder, mlir::Value reachingDefinition,
+    const mlir::DataLayout &dataLayout) {
+  getResult().replaceAllUsesWith(reachingDefinition);
+  return mlir::DeletionKind::Delete;
+}
+
+// -----------------------------------------------------------------------------
+// StoreOp: PromotableMemOpInterface
+// -----------------------------------------------------------------------------
+
+bool StoreOp::loadsFrom(const mlir::MemorySlot &slot) { return false; }
+
+bool StoreOp::storesTo(const mlir::MemorySlot &slot) {
+  return getDest() == slot.ptr;
+}
+
+mlir::Value StoreOp::getStored(const mlir::MemorySlot &slot,
+                               mlir::OpBuilder &builder,
+                               mlir::Value reachingDef,
+                               const mlir::DataLayout &dataLayout) {
+  return getSrc();
+}
+
+bool StoreOp::canUsesBeRemoved(
+    const mlir::MemorySlot &slot,
+    const llvm::SmallPtrSetImpl<mlir::OpOperand *> &blockingUses,
+    llvm::SmallVectorImpl<mlir::OpOperand *> &newBlockingUses,
+    const mlir::DataLayout &dataLayout) {
+  if (blockingUses.size() != 1)
+    return false;
+
+  mlir::Value blockingUse = (*blockingUses.begin())->get();
+  return blockingUse == slot.ptr && getDest() == slot.ptr &&
+         getSrc() != slot.ptr && getSrc().getType() == slot.elemType;
+}
+
+mlir::DeletionKind StoreOp::removeBlockingUses(
+    const mlir::MemorySlot &slot,
+    const llvm::SmallPtrSetImpl<mlir::OpOperand *> &blockingUses,
+    mlir::OpBuilder &builder, mlir::Value reachingDefinition,
+    const mlir::DataLayout &dataLayout) {
+  return mlir::DeletionKind::Delete;
 }
 
 } // namespace bir

--- a/lib/BIR/Pipelines.cpp
+++ b/lib/BIR/Pipelines.cpp
@@ -15,6 +15,7 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangOptimizeStructLayoutPass());
   pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
+  pm.addPass(mlir::createMem2Reg());
   pm.addPass(mlir::createTrivialDeadCodeEliminationPass());
   pm.addPass(mlir::createSymbolDCEPass());
   pm.addPass(createBelalangInsertStackMapsPass());

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:MemorySlotInterfaces",
         "@llvm-project//mlir:ControlFlowToLLVM",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",

--- a/tests/BIR/Transforms/Mem2Reg/BUILD.bazel
+++ b/tests/BIR/Transforms/Mem2Reg/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/Mem2Reg/cfg.mlir
+++ b/tests/BIR/Transforms/Mem2Reg/cfg.mlir
@@ -1,0 +1,61 @@
+// RUN: %bir-opt --split-input-file --bir-flatten-cfg --mem2reg %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @if_join
+// CHECK-NOT:   bir.alloc_stack
+// CHECK:       bir.cond_br %{{.*}} ^bb1, ^bb2
+// CHECK:     ^bb1:
+// CHECK:       %[[ONE:.*]] = bir.constant #bir.int<1> : !bir.int
+// CHECK:       cf.br ^bb3(%[[ONE]] : !bir.int)
+// CHECK:     ^bb2:
+// CHECK:       %[[TWO:.*]] = bir.constant #bir.int<2> : !bir.int
+// CHECK:       cf.br ^bb3(%[[TWO]] : !bir.int)
+// CHECK:     ^bb3(%[[JOIN:.*]]: !bir.int):
+// CHECK:       bir.print %[[JOIN]] : !bir.int
+// CHECK-NEXT:  bir.return
+bir.func @if_join() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.int>
+  %1 = bir.constant #bir.bool<true> : !bir.bool
+  bir.if %1 {
+    %2 = bir.constant #bir.int<1> : !bir.int
+    bir.store %2 to %0 : !bir.int to !bir.ref<!bir.int>
+    bir.yield
+  } else {
+    %3 = bir.constant #bir.int<2> : !bir.int
+    bir.store %3 to %0 : !bir.int to !bir.ref<!bir.int>
+    bir.yield
+  }
+  %4 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %4 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @loop_carried
+// CHECK-NOT:   bir.alloc_stack
+// CHECK:       %[[ZERO:.*]] = bir.constant #bir.int<0> : !bir.int
+// CHECK:       cf.br ^bb1(%[[ZERO]] : !bir.int)
+// CHECK:     ^bb1(%[[ITER:.*]]: !bir.int):
+// CHECK:       bir.cond_br %{{.*}} ^bb2, ^bb3
+// CHECK:     ^bb2:
+// CHECK:       %[[ONE:.*]] = bir.constant #bir.int<1> : !bir.int
+// CHECK:       cf.br ^bb1(%[[ONE]] : !bir.int)
+// CHECK:     ^bb3:
+// CHECK:       bir.print %[[ITER]] : !bir.int
+// CHECK-NEXT:  bir.return
+bir.func @loop_carried() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.int>
+  %1 = bir.constant #bir.int<0> : !bir.int
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  bir.while {
+    %2 = bir.constant #bir.bool<true> : !bir.bool
+    bir.condition %2
+  } do {
+    %3 = bir.constant #bir.int<1> : !bir.int
+    bir.store %3 to %0 : !bir.int to !bir.ref<!bir.int>
+    bir.yield
+  }
+  %4 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %4 : !bir.int
+  bir.return
+}

--- a/tests/BIR/Transforms/Mem2Reg/mem2reg.mlir
+++ b/tests/BIR/Transforms/Mem2Reg/mem2reg.mlir
@@ -1,0 +1,59 @@
+// RUN: %bir-opt --split-input-file --mem2reg %s | %FileCheck %s
+
+// CHECK-LABEL: bir.func @straight
+// CHECK-NEXT:  %[[VALUE:.*]] = bir.constant #bir.int<42> : !bir.int
+// CHECK-NEXT:  bir.print %[[VALUE]] : !bir.int
+// CHECK-NEXT:  bir.return
+bir.func @straight() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.int>
+  %1 = bir.constant #bir.int<42> : !bir.int
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %2 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @default_load
+// CHECK-NEXT:  %[[ZERO:.*]] = bir.constant #bir.int<0> : !bir.int
+// CHECK-NEXT:  bir.print %[[ZERO]] : !bir.int
+// CHECK-NEXT:  bir.return
+bir.func @default_load() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.int>
+  %1 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %1 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @heap_not_promoted
+// CHECK-NEXT:  %[[HEAP:.*]] = bir.alloc_heap : !bir.ref<!bir.int>
+// CHECK-NEXT:  %[[VALUE:.*]] = bir.constant #bir.int<7> : !bir.int
+// CHECK-NEXT:  bir.store %[[VALUE]] to %[[HEAP]] : !bir.int to !bir.ref<!bir.int>
+// CHECK-NEXT:  %[[LOAD:.*]] = bir.load %[[HEAP]] : (!bir.ref<!bir.int>) -> !bir.int
+// CHECK-NEXT:  bir.print %[[LOAD]] : !bir.int
+// CHECK-NEXT:  bir.return
+bir.func @heap_not_promoted() {
+  %0 = bir.alloc_heap : !bir.ref<!bir.int>
+  %1 = bir.constant #bir.int<7> : !bir.int
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.print %2 : !bir.int
+  bir.return
+}
+
+// -----
+
+// CHECK-LABEL: bir.func @blocked_get_member
+// CHECK:       bir.alloc_stack
+// CHECK:       bir.get_member
+// CHECK:       bir.store
+bir.func @blocked_get_member() {
+  %0 = bir.alloc_stack : !bir.ref<!bir.struct<"T", {!bir.int}>>
+  %1 = bir.get_member %0[0] {name = "x"} : !bir.ref<!bir.struct<"T", {!bir.int}>> -> !bir.ref<!bir.int>
+  %2 = bir.constant #bir.int<1> : !bir.int
+  bir.store %2 to %1 : !bir.int to !bir.ref<!bir.int>
+  bir.return
+}

--- a/tests/LLVMGen/functions.bel
+++ b/tests/LLVMGen/functions.bel
@@ -5,26 +5,17 @@
 
 # CHECK-LABEL:define i64 @fn.main.anon(
 # CHECK-SAME:     i64 %[[ARG0:.*]], i64 %[[ARG1:.*]]) {
-# CHECK-NEXT:   %[[V0:.*]] = alloca i64, i64 1, align 8
-# CHECK-NEXT:   store i64 %[[ARG0]], ptr %[[V0]], align 4
-# CHECK-NEXT:   %[[V1:.*]] = alloca i64, i64 1, align 8
-# CHECK-NEXT:   store i64 %[[ARG1]], ptr %[[V1]], align 4
-# CHECK-NEXT:   %[[V2:.*]] = load i64, ptr %[[V0]], align 4
-# CHECK-NEXT:   %[[V3:.*]] = load i64, ptr %[[V1]], align 4
-# CHECK-NEXT:   %[[V4:.*]] = add i64 %[[V2]], %[[V3]]
-# CHECK-NEXT:   ret i64 %[[V4]]
+# CHECK-NEXT:   %[[V0:.*]] = add i64 %[[ARG0]], %[[ARG1]]
+# CHECK-NEXT:   ret i64 %[[V0]]
 # CHECK-NEXT: }
 
 # CHECK-LABEL:define i64 @main() {
-# CHECK-NEXT:   %[[V5:.*]] = alloca ptr, i64 1, align 8
-# CHECK-NEXT:   store ptr @fn.main.anon, ptr %[[V5]], align 8
-# CHECK-NEXT:   %[[V6:.*]] = load ptr, ptr %[[V5]], align 8
-# CHECK-NEXT:   %[[V7:.*]] = call i64 %[[V6]](i64 2, i64 3)
-# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %[[V5]])
-# CHECK-NEXT:   %[[V8:.*]] = call ptr @brt_gc_alloc(i64 8)
-# CHECK-NEXT:   store i64 %[[V7]], ptr %[[V8]], align 4
-# CHECK-NEXT:   %[[V9:.*]] = load i64, ptr %[[V8]], align 4
-# CHECK-NEXT:   call void @brt_print_int(i64 %[[V9]])
+# CHECK-NEXT:   %[[RESULT:.*]] = call i64 @fn.main.anon(i64 2, i64 3)
+# CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 0)
+# CHECK-NEXT:   %[[MEM:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   store i64 %[[RESULT]], ptr %[[MEM]], align 4
+# CHECK-NEXT:   %[[VAL:.*]] = load i64, ptr %[[MEM]], align 4
+# CHECK-NEXT:   call void @brt_print_int(i64 %[[VAL]])
 # CHECK-NEXT:   ret i64 0
 # CHECK-NEXT: }
 

--- a/tests/LLVMGen/stackmap.bel
+++ b/tests/LLVMGen/stackmap.bel
@@ -2,12 +2,9 @@
 
 # CHECK-LABEL:define i64 @main() {
 
-# CHECK:        %[[V0:.*]] = alloca i64, i64 1, align 8
-
 # CHECK:        call void (i64, i32, ...) @llvm.experimental.stackmap(
 # CHECK-SAME:     i64 {{[0-9]+}},
-# CHECK-SAME:     i32 0,
-# CHECK-SAME:     ptr %[[V0]]
+# CHECK-SAME:     i32 0
 # CHECK-SAME:   )
 # CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
 


### PR DESCRIPTION
This change adds the Mem2Reg interfaces to the required ops to utilize MLIR's builtin mem2reg pass. A lot of the implementation takes inspiration from ClangIR, memref dialect, and the LLVM dialect.