### PR TITLE
[bir][LoweringPipeline] Add options for enabling Mem2Reg and DCE

### DIFF
--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -1,5 +1,6 @@
 #include "belalang/AST/ASTDumper.h"
 #include "belalang/AST/Parser.h"
+#include "belalang/BIR/Passes.h"
 #include "belalang/BIRGen/BIRGen.h"
 #include "belalang/Diag/Diag.h"
 #include "belalang/LLVMGen/LLVMGen.h"
@@ -10,6 +11,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "Cmds.h"
 
@@ -42,6 +44,54 @@ static std::string escapeString(llvm::StringRef str) {
   return result;
 }
 
+static bool parseBoolean(std::string_view value, bool &result) {
+  if (value == "true") {
+    result = true;
+    return true;
+  }
+  if (value == "false") {
+    result = false;
+    return true;
+  }
+  return false;
+}
+
+static bool parseBIRGenOption(std::string_view option,
+                              belalang::bir::BIRLoweringPipelineOptions &opts) {
+  size_t eq = option.find('=');
+  if (eq == std::string_view::npos) {
+    std::cerr << "error: malformed BIRGen option: " << option << "\n";
+    std::cerr << "hint: expected <name>=<true|false>\n";
+    return false;
+  }
+
+  std::string_view name = option.substr(0, eq);
+  std::string_view rawValue = option.substr(eq + 1);
+
+  if (name == "enable-dce") {
+    if (!parseBoolean(rawValue, opts.enableDCE.getValue())) {
+      std::cerr << "error: invalid value for BIRGen option '" << name
+                << "': " << rawValue << "\n";
+      std::cerr << "hint: expected true or false\n";
+      return false;
+    }
+    return true;
+  }
+
+  if (name == "enable-mem2reg") {
+    if (!parseBoolean(rawValue, opts.enableMem2Reg.getValue())) {
+      std::cerr << "error: invalid value for BIRGen option '" << name
+                << "': " << rawValue << "\n";
+      std::cerr << "hint: expected true or false\n";
+      return false;
+    }
+    return true;
+  }
+
+  std::cerr << "error: unknown BIRGen option: " << name << "\n";
+  return false;
+}
+
 namespace belalang {
 namespace cmd {
 
@@ -57,6 +107,7 @@ enum class EmitTarget {
 
 int build(muopt::Parser &parser) {
   auto emit = EmitTarget::Exe;
+  bir::BIRLoweringPipelineOptions birOptions;
   std::string source;
 
   while (auto arg = parser.next()) {
@@ -74,6 +125,15 @@ int build(muopt::Parser &parser) {
         emit = EmitTarget::Llvm;
       if (value == "exe")
         emit = EmitTarget::Exe;
+    }
+    if (arg.has_value() && arg->is_long("bir-lowering-pipeline")) {
+      auto value = parser.arg_value();
+      if (!value.has_value()) {
+        std::cerr << "error: missing value for --birgen\n";
+        return 1;
+      }
+      if (!parseBIRGenOption(*value, birOptions))
+        return 1;
     }
     if (arg.has_value() && arg->is_plain()) {
       source = arg->as_str();
@@ -149,7 +209,8 @@ int build(muopt::Parser &parser) {
     birgen::BIRGen birgen(astCtx, diagEngine);
     birgen.generateProgram(prog);
 
-    if (emit == EmitTarget::BirLowered && !birgen.runLoweringPipeline()) {
+    if (emit == EmitTarget::BirLowered &&
+        !birgen.runLoweringPipeline(birOptions)) {
       std::cerr << "error: BIR lowering pipeline failed\n";
       return 1;
     }
@@ -171,7 +232,7 @@ int build(muopt::Parser &parser) {
     birgen::BIRGen birgen(astCtx, diagEngine);
     birgen.generateProgram(prog);
 
-    if (!birgen.runLoweringPipeline()) {
+    if (!birgen.runLoweringPipeline(birOptions)) {
       std::cerr << "error: BIR lowering pipeline failed\n";
       return 1;
     }
@@ -194,7 +255,7 @@ int build(muopt::Parser &parser) {
     birgen::BIRGen birgen(astCtx, diagEngine);
     birgen.generateProgram(prog);
 
-    if (!birgen.runLoweringPipeline()) {
+    if (!birgen.runLoweringPipeline(birOptions)) {
       std::cerr << "error: BIR lowering pipeline failed\n";
       return 1;
     }

--- a/include/belalang/BIR/Passes.h
+++ b/include/belalang/BIR/Passes.h
@@ -33,7 +33,21 @@ void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns,
 // -----------------------------------------------------------------------------
 
 struct BIRLoweringPipelineOptions
-    : public mlir::PassPipelineOptions<BIRLoweringPipelineOptions> {};
+    : public mlir::PassPipelineOptions<BIRLoweringPipelineOptions> {
+  mlir::detail::PassOptions::Option<bool> enableDCE{
+      *this,
+      "enable-dce",
+      llvm::cl::desc("Enables dead code elimination."),
+      llvm::cl::init(true),
+  };
+
+  mlir::detail::PassOptions::Option<bool> enableMem2Reg{
+      *this,
+      "enable-mem2reg",
+      llvm::cl::desc("Enables mem2reg."),
+      llvm::cl::init(true),
+  };
+};
 
 void buildBIRLoweringPipeline(mlir::OpPassManager &pm);
 void buildBIRLoweringPipeline(mlir::OpPassManager &pm,

--- a/include/belalang/BIRGen/BIRGen.h
+++ b/include/belalang/BIRGen/BIRGen.h
@@ -12,6 +12,10 @@
 #include <string>
 
 namespace belalang {
+namespace bir {
+struct BIRLoweringPipelineOptions;
+} // namespace bir
+
 namespace birgen {
 
 class BIRGen : public ast::ASTVisitor<BIRGen, mlir::Value> {
@@ -25,6 +29,7 @@ public:
 
   mlir::ModuleOp generateProgram(ast::Program *prog);
   bool runLoweringPipeline();
+  bool runLoweringPipeline(const bir::BIRLoweringPipelineOptions &options);
   std::string dumpToString() const;
 
 #define STMT(name) mlir::Value visit##name##Stmt(ast::name##Stmt *);

--- a/lib/BIR/Pipelines.cpp
+++ b/lib/BIR/Pipelines.cpp
@@ -15,9 +15,13 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangOptimizeStructLayoutPass());
   pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
-  pm.addPass(mlir::createMem2Reg());
-  pm.addPass(mlir::createTrivialDeadCodeEliminationPass());
-  pm.addPass(mlir::createSymbolDCEPass());
+  if (options.enableMem2Reg) {
+    pm.addPass(mlir::createMem2Reg());
+  }
+  if (options.enableDCE) {
+    pm.addPass(mlir::createTrivialDeadCodeEliminationPass());
+    pm.addPass(mlir::createSymbolDCEPass());
+  }
   pm.addPass(createBelalangInsertStackMapsPass());
   pm.addPass(createBelalangVerifyLoweredFormPass());
 }

--- a/lib/BIRGen/BIRGen.cpp
+++ b/lib/BIRGen/BIRGen.cpp
@@ -507,8 +507,13 @@ void BIRGen::buildMainReturn() {
 }
 
 bool BIRGen::runLoweringPipeline() {
+  return runLoweringPipeline(bir::BIRLoweringPipelineOptions());
+}
+
+bool BIRGen::runLoweringPipeline(
+    const bir::BIRLoweringPipelineOptions &options) {
   mlir::PassManager pm(&context);
-  bir::buildBIRLoweringPipeline(pm);
+  bir::buildBIRLoweringPipeline(pm, options);
   return mlir::succeeded(pm.run(module));
 }
 

--- a/tests/BIR/Transforms/DCE/pipeline.mlir
+++ b/tests/BIR/Transforms/DCE/pipeline.mlir
@@ -1,4 +1,5 @@
 // RUN: %bir-opt --split-input-file --bir-lowering-pipeline %s | %FileCheck %s
+// RUN: %bir-opt --split-input-file --bir-lowering-pipeline=enable-dce=false %s | %FileCheck --check-prefix=NODCE %s
 
 // CHECK-LABEL: bir.func @drops_dead_pure_work
 // CHECK-NOT: bir.add
@@ -18,8 +19,14 @@ bir.func @drops_dead_pure_work() {
 // -----
 
 // CHECK-NOT: @fn.drops_unused_func_expr.anon
+
 // CHECK-LABEL: bir.func @drops_unused_func_expr
 // CHECK-NEXT: bir.return
+
+// NODCE-LABEL: bir.func private @fn.drops_unused_func_expr.anon
+// NODCE-LABEL: bir.func @drops_unused_func_expr
+// NODCE-NEXT: bir.return
+
 bir.func @drops_unused_func_expr() {
   %0 = bir.func_expr : () -> () {
     bir.return

--- a/tests/LLVMGen/stackmap.bel
+++ b/tests/LLVMGen/stackmap.bel
@@ -1,12 +1,14 @@
-# RUN: %belalang build --emit=llvm %s | %FileCheck %s
+# RUN: %belalang build --emit=llvm --bir-lowering-pipeline=enable-mem2reg=false %s | %FileCheck %s
 
 # CHECK-LABEL:define i64 @main() {
+# CHECK:        %[[X:.*]] = alloca i64, i64 1, align 8
 
 # CHECK:        call void (i64, i32, ...) @llvm.experimental.stackmap(
 # CHECK-SAME:     i64 {{[0-9]+}},
-# CHECK-SAME:     i32 0
+# CHECK-SAME:     i32 0,
+# CHECK-SAME:     ptr %[[X]]
 # CHECK-SAME:   )
-# CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[Y:.*]] = call ptr @brt_gc_alloc(i64 8)
 
 # CHECK:        ret i64 0
 # CHECK-NEXT: }


### PR DESCRIPTION
Adds options to BIRLoweringPipelineOptions named `enable-dce` and `enable-mem2reg`, both default to true. This should be used for tests to see the diff between enabled and disabled. This option is also propagated to the belalang binary via `--bir-lowering-pipeline=` option.

The `LLVMGen/stackmap.bel` test was previously changed in #354 due to the Mem2Reg pass changing how `alloc_stack` is lowered. This change should effectively revert the `LLVMGen/stackmap.bel` test to before #354.