### PR TITLE
[brt][gc] Implement semi-space moving GC

### DIFF
--- a/brt/.clang-format
+++ b/brt/.clang-format
@@ -1,0 +1,12 @@
+# clang-format version 21.1.8
+BasedOnStyle: LLVM
+
+BinPackParameters: AlwaysOnePerLine # deprecated in version 23
+BinPackArguments: false # deprecated in version 23
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterReturnType: All

--- a/brt/src/gc.c
+++ b/brt/src/gc.c
@@ -11,49 +11,255 @@
 #include <sys/mman.h>
 
 struct gc_obj {
+  /// Aligned payload size in bytes.
   size_t size;
-  bool marked;
-  struct gc_obj *next;
+  /// Number of pointer fields in the payload.
+  size_t pointer_count;
+  /// Array of byte offsets identifying where pointer fields occur.
+  const uint32_t *pointer_offsets;
+  /// Used during copying collection.
+  struct gc_obj *forwarding;
+  /// Flexible array member representing the object payload.
   unsigned char data[];
 };
 
-struct gc_heap {
-  uintptr_t hp;
-  uintptr_t limit;
-  uintptr_t space;
-  struct gc_obj *objects;
+struct gc_root_frame {
+  /// Number of root slots in this frame.
+  size_t count;
+  /// Array of addresses of pointer variables.
+  void ***roots;
+  /// Links to the previous root frame.
+  struct gc_root_frame *prev;
 };
 
-/// Global heap instance.
-static struct gc_heap the_heap;
+struct gc_semispace {
+  /// Points to the start of the semispace.
+  uintptr_t start;
+  /// Heap pointer.
+  uintptr_t hp;
+  /// Points to the end of the semispace. (Exclusive)
+  uintptr_t limit;
+};
 
-/// Initialize GC heap.
-static void gc_heap_init(size_t size) {
+struct gc_heap {
+  /// from-space.
+  struct gc_semispace fromsp;
+  /// to-space.
+  struct gc_semispace tosp;
+  /// Top of the registered root-frame stack.
+  struct gc_root_frame *roots;
+};
+
+/// Converts a payload pointer back to its object header.
+static struct gc_obj *
+gc_obj_from_data(void *ptr)
+{
+  return (struct gc_obj *)((uintptr_t)ptr - offsetof(struct gc_obj, data));
+}
+
+/// Creates a new semispace with the specified size;
+static struct gc_semispace
+gc_semispace_create(size_t size)
+{
   void *mem =
       mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
   if (mem == MAP_FAILED)
     brt_fatal("mmap failed");
 
-  the_heap.space = the_heap.hp = (uintptr_t)mem;
-  the_heap.limit = the_heap.hp + size;
+  struct gc_semispace sp;
+  sp.start = sp.hp = (uintptr_t)mem;
+  sp.limit = sp.start + size;
+  return sp;
 }
 
-void brt_gc_init() { gc_heap_init(1024 * 1024); }
+/// Checks if the semispace sp contains the pointer ptr.
+static bool
+gc_semispace_contains(const struct gc_semispace *sp,
+                      const void *ptr)
+{
+  uintptr_t addr = (uintptr_t)ptr;
+  return addr >= sp->start && addr < sp->limit;
+}
 
-void *brt_gc_alloc(size_t size) {
-  uintptr_t payload_size = align_size(size);
-  uintptr_t alloc_size = sizeof(struct gc_obj) + payload_size;
+/// Reserves aligned raw storage in a semispace.
+static void *
+gc_semispace_alloc_in(struct gc_semispace *sp,
+                      size_t size)
+{
+  size_t aligned_size = align_size(size);
+  if (aligned_size > sp->limit - sp->hp)
+    return NULL;
 
-  if (alloc_size > the_heap.limit - the_heap.hp)
-    brt_fatal("out of GC heap memory");
+  void *memory = (void *)sp->hp;
+  sp->hp += aligned_size;
+  return memory;
+}
 
-  struct gc_obj *obj = (struct gc_obj *)the_heap.hp;
+/// Initialize GC heap.
+static void
+gc_heap_init(struct gc_heap *heap,
+             size_t size)
+{
+  size_t semispace_size = align_size(size / 2);
+  if (semispace_size <= sizeof(struct gc_obj))
+    brt_fatal("GC heap too small");
+
+  heap->fromsp = gc_semispace_create(semispace_size);
+  heap->tosp = gc_semispace_create(semispace_size);
+  heap->roots = NULL;
+}
+
+/// Performs bump allocation in the active semispace and initializes the object
+/// header and zeroed payload.
+static void *
+gc_heap_alloc_obj(struct gc_heap *heap,
+                  size_t size,
+                  size_t pointer_count,
+                  const uint32_t *pointer_offsets)
+{
+  size_t payload_size = align_size(size);
+  size_t object_size = sizeof(struct gc_obj) + payload_size;
+
+  struct gc_obj *obj = gc_semispace_alloc_in(&heap->fromsp, object_size);
+  if (!obj)
+    return NULL;
+
   obj->size = payload_size;
-  obj->marked = false;
-  obj->next = the_heap.objects;
-  the_heap.objects = obj;
-  the_heap.hp += alloc_size;
+  obj->pointer_count = pointer_count;
+  obj->pointer_offsets = pointer_offsets;
+  obj->forwarding = NULL;
 
   memset(obj->data, 0, payload_size);
   return obj->data;
+}
+
+/// Copies a live object to to-space. It uses the forwarding pointer to ensure
+/// each object is copied only once.
+static void *
+gc_heap_copy_obj(struct gc_heap *heap,
+                 void *ptr)
+{
+  if (ptr == NULL || !gc_semispace_contains(&heap->fromsp, ptr))
+    return ptr;
+
+  struct gc_obj *old = gc_obj_from_data(ptr);
+  if (old->forwarding)
+    return old->forwarding->data;
+
+  struct gc_obj *new_obj =
+      gc_semispace_alloc_in(&heap->tosp, sizeof(struct gc_obj) + old->size);
+  if (!new_obj)
+    brt_fatal("out of GC heap memory");
+
+  memcpy(new_obj, old, sizeof(struct gc_obj) + old->size);
+  new_obj->forwarding = NULL;
+  old->forwarding = new_obj;
+  return new_obj->data;
+}
+
+/// Replaces a root or object field with its relocated pointer.
+static void
+gc_heap_update_slot(struct gc_heap *heap,
+                    void **slot)
+{
+  if (slot)
+    *slot = gc_heap_copy_obj(heap, *slot);
+}
+
+/// Traverses copied objects and updates fields listed in their pointer-offset
+/// metadata.
+static void
+gc_heap_scan_copied_objects(struct gc_heap *heap)
+{
+  uintptr_t it = heap->tosp.start;
+  while (it < heap->tosp.hp) {
+    struct gc_obj *obj = (struct gc_obj *)it;
+    for (size_t i = 0; i < obj->pointer_count; ++i) {
+      uint32_t offset = obj->pointer_offsets[i];
+      if (offset + sizeof(void *) <= obj->size)
+        gc_heap_update_slot(heap, (void **)(obj->data + offset));
+    }
+    it += align_size(sizeof(struct gc_obj) + obj->size);
+  }
+}
+
+/// Global heap instance.
+static struct gc_heap the_heap;
+
+void
+brt_gc_init()
+{
+  gc_heap_init(&the_heap, 1024 * 1024);
+}
+
+void
+brt_gc_push_roots(size_t count,
+                  void ***roots)
+{
+  struct gc_root_frame *frame = malloc(sizeof(struct gc_root_frame));
+  if (!frame)
+    brt_fatal("malloc failed");
+
+  frame->count = count;
+  frame->roots = roots;
+  frame->prev = the_heap.roots;
+  the_heap.roots = frame;
+}
+
+void
+brt_gc_pop_roots()
+{
+  if (!the_heap.roots)
+    brt_fatal("GC root stack underflow");
+
+  struct gc_root_frame *frame = the_heap.roots;
+  the_heap.roots = frame->prev;
+  free(frame);
+}
+
+void
+brt_gc_collect()
+{
+  the_heap.tosp.hp = the_heap.tosp.start;
+
+  for (struct gc_root_frame *frame = the_heap.roots; frame;
+       frame = frame->prev) {
+    for (size_t i = 0; i < frame->count; ++i)
+      gc_heap_update_slot(&the_heap, frame->roots[i]);
+  }
+
+  gc_heap_scan_copied_objects(&the_heap);
+
+  struct gc_semispace old_fromsp = the_heap.fromsp;
+  the_heap.fromsp = the_heap.tosp;
+  the_heap.tosp = old_fromsp;
+
+  the_heap.tosp.hp = the_heap.tosp.start;
+}
+
+void *
+brt_gc_alloc_layout(size_t size,
+                    size_t pointer_count,
+                    const uint32_t *pointer_offsets)
+{
+  void *ptr =
+      gc_heap_alloc_obj(&the_heap, size, pointer_count, pointer_offsets);
+
+  // Retry if fail.
+  if (!ptr) {
+    brt_gc_collect();
+    ptr = gc_heap_alloc_obj(&the_heap, size, pointer_count, pointer_offsets);
+  }
+
+  // We really failed.
+  if (!ptr)
+    brt_fatal("out of GC heap memory");
+
+  return ptr;
+}
+
+void *
+brt_gc_alloc(size_t size)
+{
+  return brt_gc_alloc_layout(size, 0, NULL);
 }

--- a/brt/src/gc.h
+++ b/brt/src/gc.h
@@ -2,13 +2,27 @@
 #define BRT_GC_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void brt_gc_init();
-void *brt_gc_alloc(size_t size);
+void
+brt_gc_init();
+void *
+brt_gc_alloc(size_t size);
+void *
+brt_gc_alloc_layout(size_t size,
+                    size_t pointer_count,
+                    const uint32_t *pointer_offsets);
+void
+brt_gc_push_roots(size_t count,
+                  void ***roots);
+void
+brt_gc_pop_roots();
+void
+brt_gc_collect();
 
 #ifdef __cplusplus
 }

--- a/brt/src/gc_test.cpp
+++ b/brt/src/gc_test.cpp
@@ -5,6 +5,17 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace {
+
+struct Node {
+  void *child;
+  std::uint64_t value;
+};
+
+const std::uint32_t kNodePointerOffsets[] = {offsetof(Node, child)};
+
+} // namespace
+
 TEST(GCTest, AllocatesAlignedZeroInitializedMemory) {
   brt_gc_init();
 
@@ -26,4 +37,49 @@ TEST(GCTest, ReturnsDistinctAllocations) {
   ASSERT_NE(first, nullptr);
   ASSERT_NE(second, nullptr);
   EXPECT_NE(first, second);
+}
+
+TEST(GCTest,
+     CollectionUpdatesRoots)
+{
+  brt_gc_init();
+
+  auto *root =
+      static_cast<std::uint64_t *>(brt_gc_alloc(sizeof(std::uint64_t)));
+  *root = 42;
+  auto *original = root;
+  void **roots[] = {reinterpret_cast<void **>(&root)};
+
+  brt_gc_push_roots(1, roots);
+  brt_gc_collect();
+  brt_gc_pop_roots();
+
+  EXPECT_NE(root, original);
+  EXPECT_EQ(*root, 42);
+}
+
+TEST(GCTest,
+     CollectionUpdatesPointerFields)
+{
+  brt_gc_init();
+
+  auto *child =
+      static_cast<std::uint64_t *>(brt_gc_alloc(sizeof(std::uint64_t)));
+  *child = 99;
+  auto *parent = static_cast<Node *>(
+      brt_gc_alloc_layout(sizeof(Node), 1, kNodePointerOffsets));
+  parent->child = child;
+  parent->value = 7;
+
+  auto *originalChild = child;
+  void **roots[] = {reinterpret_cast<void **>(&parent)};
+
+  brt_gc_push_roots(1, roots);
+  brt_gc_collect();
+  brt_gc_pop_roots();
+
+  ASSERT_NE(parent->child, nullptr);
+  EXPECT_NE(parent->child, originalChild);
+  EXPECT_EQ(*static_cast<std::uint64_t *>(parent->child), 99);
+  EXPECT_EQ(parent->value, 7);
 }

--- a/include/belalang/BIR/BRTUtils.h
+++ b/include/belalang/BIR/BRTUtils.h
@@ -8,6 +8,7 @@ constexpr llvm::StringRef kPrintFloat = "brt_print_float";
 constexpr llvm::StringRef kPrintString = "brt_print_string";
 constexpr llvm::StringRef kPrintBool = "brt_print_bool";
 constexpr llvm::StringRef kGCAlloc = "brt_gc_alloc";
+constexpr llvm::StringRef kGCAllocLayout = "brt_gc_alloc_layout";
 constexpr llvm::StringRef kInit = "brt_init";
 
 #endif // BELALANG_BIR_BRTUTILS_H_

--- a/include/belalang/BIR/Passes.td
+++ b/include/belalang/BIR/Passes.td
@@ -37,7 +37,8 @@ def BelalangVerifyLoweredFormPass : Pass<"bir-verify-lowered-form"> {
 
 def BelalangOptimizeStructLayoutPass : Pass<"bir-optimize-struct-layout"> {
   let summary = "compute compact physical layouts for BIR structs";
-  let dependentDialects = ["::belalang::bir::BIRDialect"];
+  let dependentDialects = ["::belalang::bir::BIRDialect",
+                           "::mlir::LLVM::LLVMDialect"];
 }
 
 def BelalangBIRToLLVMPass : Pass<"convert-bir-to-llvm"> {

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -20,6 +20,71 @@ namespace {
 using namespace mlir;
 using namespace belalang;
 
+static void collectGCPointerOffsets(mlir::Type type,
+                                    const mlir::DataLayout &dataLayout,
+                                    uint64_t baseOffset,
+                                    llvm::SmallVectorImpl<uint32_t> &offsets) {
+  auto structType = mlir::dyn_cast<bir::StructType>(type);
+  if (!structType)
+    return;
+
+  uint64_t currentOffset = 0;
+  for (int32_t logicalIndex : structType.getInverseReorder()) {
+    mlir::Type member = structType.getMembers()[logicalIndex];
+    uint64_t memberAlign = dataLayout.getTypeABIAlignment(member);
+    currentOffset = llvm::alignTo(currentOffset, memberAlign);
+    if (mlir::isa<bir::RefType>(member))
+      offsets.push_back(static_cast<uint32_t>(baseOffset + currentOffset));
+    else
+      collectGCPointerOffsets(member, dataLayout, baseOffset + currentOffset,
+                              offsets);
+    currentOffset += dataLayout.getTypeSize(member).getFixedValue();
+  }
+}
+
+static llvm::SmallVector<uint32_t>
+getGCPointerOffsets(mlir::Type type, const mlir::DataLayout &dataLayout) {
+  llvm::SmallVector<uint32_t> offsets;
+  collectGCPointerOffsets(type, dataLayout, 0, offsets);
+  return offsets;
+}
+
+static std::string getGCLayoutGlobalName(mlir::Type type,
+                                         llvm::ArrayRef<uint32_t> offsets) {
+  llvm::hash_code hash = llvm::hash_combine(type, offsets.size());
+  for (uint32_t offset : offsets)
+    hash = llvm::hash_combine(hash, offset);
+  return "gc.ptr_offsets." + std::to_string(static_cast<size_t>(hash));
+}
+
+static mlir::Value getOrCreatePointerOffsetsGlobal(
+    mlir::Location loc, mlir::ModuleOp module, mlir::Type referentType,
+    llvm::ArrayRef<uint32_t> offsets, mlir::OpBuilder &builder) {
+  if (offsets.empty())
+    return LLVM::ZeroOp::create(
+        builder, loc, LLVM::LLVMPointerType::get(module.getContext()));
+
+  mlir::MLIRContext *ctx = module.getContext();
+  std::string globalName = getGCLayoutGlobalName(referentType, offsets);
+  auto i32Ty = mlir::IntegerType::get(ctx, 32);
+  auto arrTy = LLVM::LLVMArrayType::get(i32Ty, offsets.size());
+
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    if (!module.lookupSymbol<LLVM::GlobalOp>(globalName)) {
+      llvm::SmallVector<mlir::Attribute> attrs;
+      for (uint32_t offset : offsets)
+        attrs.push_back(builder.getI32IntegerAttr(offset));
+      LLVM::GlobalOp::create(builder, loc, arrTy, true, LLVM::Linkage::Private,
+                             globalName, builder.getArrayAttr(attrs));
+    }
+  }
+
+  return LLVM::AddressOfOp::create(builder, loc,
+                                   LLVM::LLVMPointerType::get(ctx), globalName);
+}
+
 std::optional<mlir::Attribute>
 buildStructConstant(const mlir::TypeConverter &typeConverter,
                     mlir::MLIRContext *ctx, bir::StructAttr structAttr) {
@@ -498,22 +563,32 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
     uint64_t typeSize = dataLayout.getTypeSize(referentLLVMTy);
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
-    if (!module.lookupSymbol(kGCAlloc)) {
+    if (!module.lookupSymbol(kGCAllocLayout)) {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(module.getBody());
       auto funcType = LLVM::LLVMFunctionType::get(
-          LLVM::LLVMPointerType::get(ctx), mlir::IntegerType::get(ctx, 64));
-      LLVM::LLVMFuncOp::create(rewriter, loc, kGCAlloc, funcType);
+          LLVM::LLVMPointerType::get(ctx),
+          {mlir::IntegerType::get(ctx, 64), mlir::IntegerType::get(ctx, 64),
+           LLVM::LLVMPointerType::get(ctx)});
+      LLVM::LLVMFuncOp::create(rewriter, loc, kGCAllocLayout, funcType);
     }
 
     auto i64Type = mlir::IntegerType::get(ctx, 64);
     auto sizeVal = LLVM::ConstantOp::create(
         rewriter, loc, i64Type, rewriter.getI64IntegerAttr(typeSize));
+    auto pointerOffsets = getGCPointerOffsets(type.getReferent(), dataLayout);
+    auto pointerCountVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type,
+        rewriter.getI64IntegerAttr(pointerOffsets.size()));
+    auto offsetsVal = getOrCreatePointerOffsetsGlobal(
+        loc, module, type.getReferent(), pointerOffsets, rewriter);
 
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
-    auto calleeAttr = FlatSymbolRefAttr::get(ctx, kGCAlloc);
-    auto allocCall = LLVM::CallOp::create(rewriter, loc, ptrType, calleeAttr,
-                                          sizeVal.getResult());
+    auto calleeAttr = FlatSymbolRefAttr::get(ctx, kGCAllocLayout);
+    auto allocCall = LLVM::CallOp::create(
+        rewriter, loc, ptrType, calleeAttr,
+        ValueRange{sizeVal.getResult(), pointerCountVal.getResult(),
+                   offsetsVal});
 
     rewriter.replaceOp(op, allocCall.getResult());
     return success();

--- a/tests/BIR/Target/LLVMIR/gc-layout.mlir
+++ b/tests/BIR/Target/LLVMIR/gc-layout.mlir
@@ -1,0 +1,14 @@
+// RUN: %bir-opt --split-input-file --bir-lowering-pipeline %s \
+// RUN: | %bir-translate --split-input-file --bir-to-llvmir \
+// RUN: | %FileCheck %s
+
+// CHECK-DAG: @gc.ptr_offsets.{{.*}} = private constant {{\[1 x i32\]}} {{\[i32 8\]}}
+// CHECK-DAG: declare ptr @brt_gc_alloc_layout(i64, i64, ptr)
+// CHECK-LABEL: define void @main() {
+// CHECK: call ptr @brt_gc_alloc_layout(i64 16, i64 1, ptr @gc.ptr_offsets.{{.*}})
+// CHECK: ret void
+
+bir.func @main() {
+  %0 = bir.alloc_heap : !bir.ref<!bir.struct<"Box", {!bir.int, !bir.ref<!bir.int>}>>
+  bir.return
+}

--- a/tests/BIR/Target/LLVMIR/string.mlir
+++ b/tests/BIR/Target/LLVMIR/string.mlir
@@ -4,13 +4,13 @@
 
 // CHECK-DAG: %bel.String = type { ptr, i64 }
 // CHECK-DAG: @str.[[H:.*]] = private constant [5 x i8] c"hello"
-// CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+// CHECK-DAG: declare ptr @brt_gc_alloc_layout(i64, i64, ptr)
 // CHECK-DAG: declare void @brt_init()
 // CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
 // CHECK-LABEL:define %bel.String @main() {
 // CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
-// CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
+// CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc_layout(i64 16, i64 0, ptr null)
 // CHECK-NEXT:   store %bel.String { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load %bel.String, ptr %[[C1]], align 8
 // CHECK-NEXT:   ret %bel.String %[[C2]]
@@ -31,14 +31,14 @@ bir.func @main() -> !bir.string {
 
 // CHECK-DAG: %bel.String = type { ptr, i64 }
 // CHECK-DAG: @str.[[H:.*]] = private constant [5 x i8] c"hello"
-// CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+// CHECK-DAG: declare ptr @brt_gc_alloc_layout(i64, i64, ptr)
 // CHECK-DAG: declare void @brt_print_string(%bel.String)
 // CHECK-DAG: declare void @brt_init()
 // CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
 // CHECK-LABEL:define void @main() {
 // CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0)
-// CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
+// CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc_layout(i64 16, i64 0, ptr null)
 // CHECK-NEXT:   store %bel.String { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load %bel.String, ptr %[[C1]], align 8
 // CHECK-NEXT:   call void @brt_print_string(%bel.String %[[C2]])

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -57,11 +57,13 @@ bir.func @main() -> !bir.int {
 
 // -----
 
-// CHECK: llvm.func @brt_gc_alloc(i64) -> !llvm.ptr
+// CHECK: llvm.func @brt_gc_alloc_layout(i64, i64, !llvm.ptr) -> !llvm.ptr
 
 // CHECK-LABEL: llvm.func @main() -> i64
 // CHECK: %[[SIZE:.*]] = llvm.mlir.constant(8 : i64) : i64
-// CHECK: %[[PTR:.*]] = llvm.call @brt_gc_alloc(%[[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK: %[[PTR_COUNT:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[OFFSETS:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: %[[PTR:.*]] = llvm.call @brt_gc_alloc_layout(%[[SIZE]], %[[PTR_COUNT]], %[[OFFSETS]]) : (i64, i64, !llvm.ptr) -> !llvm.ptr
 // CHECK: %[[VAL:.*]] = llvm.mlir.constant(12 : i64) : i64
 // CHECK: llvm.store %[[VAL]], %[[PTR]] : i64, !llvm.ptr
 // CHECK: %[[LOAD:.*]] = llvm.load %[[PTR]] : !llvm.ptr -> i64
@@ -85,5 +87,20 @@ bir.func @f()
 
 bir.func @main() {
   %0 = bir.constant #bir.fn<@f> : () -> ()
+  bir.return
+}
+
+// -----
+
+// CHECK-DAG: llvm.mlir.global private constant @gc.ptr_offsets.{{[0-9]+}}([8 : i32])
+// CHECK: llvm.func @brt_gc_alloc_layout(i64, i64, !llvm.ptr) -> !llvm.ptr
+// CHECK-LABEL: llvm.func @main()
+// CHECK: %[[SIZE:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK: %[[PTR_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[OFFSETS:.*]] = llvm.mlir.addressof {{.*}} : !llvm.ptr
+// CHECK: llvm.call @brt_gc_alloc_layout(%[[SIZE]], %[[PTR_COUNT]], %[[OFFSETS]]) : (i64, i64, !llvm.ptr) -> !llvm.ptr
+
+bir.func @main() {
+  %0 = bir.alloc_heap : !bir.ref<!bir.struct<"Box", {!bir.ref<!bir.int>, !bir.int}, reorder = [1, 0]>>
   bir.return
 }

--- a/tests/LLVMGen/functions.bel
+++ b/tests/LLVMGen/functions.bel
@@ -1,6 +1,6 @@
 # RUN: %belalang build --emit=llvm %s | %FileCheck %s
 
-# CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+# CHECK-DAG: declare ptr @brt_gc_alloc_layout(i64, i64, ptr)
 # CHECK-DAG: declare void @brt_print_int(i64)
 
 # CHECK-LABEL:define i64 @fn.main.anon(
@@ -12,7 +12,7 @@
 # CHECK-LABEL:define i64 @main() {
 # CHECK-NEXT:   %[[RESULT:.*]] = call i64 @fn.main.anon(i64 2, i64 3)
 # CHECK-NEXT:   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 0)
-# CHECK-NEXT:   %[[MEM:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[MEM:.*]] = call ptr @brt_gc_alloc_layout(i64 8, i64 0, ptr null)
 # CHECK-NEXT:   store i64 %[[RESULT]], ptr %[[MEM]], align 4
 # CHECK-NEXT:   %[[VAL:.*]] = load i64, ptr %[[MEM]], align 4
 # CHECK-NEXT:   call void @brt_print_int(i64 %[[VAL]])

--- a/tests/LLVMGen/stackmap.bel
+++ b/tests/LLVMGen/stackmap.bel
@@ -8,7 +8,7 @@
 # CHECK-SAME:     i32 0,
 # CHECK-SAME:     ptr %[[X]]
 # CHECK-SAME:   )
-# CHECK-NEXT:   %[[Y:.*]] = call ptr @brt_gc_alloc(i64 8)
+# CHECK-NEXT:   %[[Y:.*]] = call ptr @brt_gc_alloc_layout(i64 8, i64 0, ptr null)
 
 # CHECK:        ret i64 0
 # CHECK-NEXT: }

--- a/tools/bir-opt/BUILD.bazel
+++ b/tools/bir-opt/BUILD.bazel
@@ -7,6 +7,7 @@ cc_binary(
     srcs = ["bir-opt.cpp"],
     deps = [
         "//lib:BIR",
+        "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:MlirOptLib",
     ],
 )

--- a/tools/bir-opt/bir-opt.cpp
+++ b/tools/bir-opt/bir-opt.cpp
@@ -1,12 +1,14 @@
 #include "belalang/BIR/IR/BIR.h"
 #include "belalang/BIR/Passes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
-  registry.insert<belalang::bir::BIRDialect, mlir::cf::ControlFlowDialect>();
+  registry.insert<belalang::bir::BIRDialect, mlir::cf::ControlFlowDialect,
+                  mlir::LLVM::LLVMDialect>();
 
   belalang::bir::registerPasses();
   belalang::bir::registerBIRPipelines();


### PR DESCRIPTION
This change implements a semi-space moving GC algorithm for BRT. This also requires changes to the lowering, notably the runtime function alloc_heap get lowered to (from `brt_gc_alloc` to `brt_gc_alloc_layout`). This is because the latter is more complete than the former due to taking in pointer information.