### PR TITLE
[bir][FuncOp] Enforce zero or one result

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -221,6 +221,7 @@ def BIR_PrintOp : BIR_Op<"print"> {
 def BIR_FuncOp : BIR_Op<"func", [FunctionOpInterface, CallableOpInterface,
                              IsolatedFromAbove]> {
   let summary = "func";
+  let hasVerifier = 1;
 
   let arguments = (ins SymbolNameAttr:$sym_name,
       TypeAttrOf<FunctionType>:$function_type,

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -122,6 +122,13 @@ mlir::Type FuncOp::getResType() {
   return getNumResults() > 0 ? getResultTypes()[0] : mlir::Type();
 }
 
+mlir::LogicalResult FuncOp::verify() {
+  if (getFunctionType().getNumResults() > 1)
+    return emitOpError() << "supports at most one result";
+
+  return mlir::success();
+}
+
 // -----------------------------------------------------------------------------
 // FuncExprOp
 // -----------------------------------------------------------------------------

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -246,10 +246,8 @@ struct FuncOpLowering final : public OpConversionPattern<bir::FuncOp> {
       resultType = LLVM::LLVMVoidType::get(getContext());
     else if (srcType.getNumResults() == 1)
       resultType = getTypeConverter()->convertType(srcType.getResult(0));
-    else {
-      // TODO: decide on num results
-      return failure();
-    }
+    else
+      llvm_unreachable("bir.func supports at most one result.");
 
     auto llvmFuncType = LLVM::LLVMFunctionType::get(resultType, inputTypes);
 

--- a/tests/BIR/IR/func.mlir
+++ b/tests/BIR/IR/func.mlir
@@ -1,4 +1,4 @@
-// RUN: %bir-opt --split-input-file --verify-roundtrip %s | %FileCheck %s
+// RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
 
 // CHECK:      module {
 // CHECK-NEXT:   bir.func @main() {
@@ -38,12 +38,7 @@ bir.func @f(%arg0 : !bir.int) -> !bir.int {
 
 // -----
 
-// CHECK:      module {
-// CHECK-NEXT:   bir.func @f(%arg0: !bir.int) -> (!bir.int, !bir.int) {
-// CHECK-NEXT:     bir.return %arg0, %arg0 : !bir.int, !bir.int
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-
+// expected-error@+1 {{'bir.func' op supports at most one result}}
 bir.func @f(%arg0 : !bir.int) -> (!bir.int, !bir.int) {
   bir.return %arg0, %arg0 : !bir.int, !bir.int
 }


### PR DESCRIPTION
This change verifies that `bir.func` only has zero or one return result. Functions that return more than one should use a new compound type.