### PR TITLE
[bir] Implement arrays ecosystem

### DIFF
--- a/include/belalang/BIR/IR/BIRAttrs.td
+++ b/include/belalang/BIR/IR/BIRAttrs.td
@@ -57,6 +57,18 @@ def BIR_StructAttr : BIR_Attr<"Struct", "struct", [TypedAttrInterface]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def BIR_ArrayAttr : BIR_Attr<"Array", "array", [TypedAttrInterface]> {
+  let summary = "An attribute containing an array value";
+
+  let parameters = (ins
+    AttributeSelfTypeParameter<"">:$type,
+    ArrayRefParameter<"mlir::Attribute", "">:$members,
+    ArrayRefParameter<"mlir::Type", "">:$memberTypes
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 def BIR_FnAttr : BIR_Attr<"Fn", "fn", [TypedAttrInterface]> {
   let summary = "function";
 

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -528,6 +528,24 @@ def BIR_GetMemberOp : BIR_Op<"get_member", [Pure]> {
   }];
 }
 
+def BIR_GetElementOp : BIR_Op<"get_element", [Pure]> {
+  let arguments = (ins
+    BIR_ArrayType:$array,
+    IndexAttr:$index_attr
+  );
+
+  let results = (outs
+    BIR_RefType:$result
+  );
+
+  let assemblyFormat = [{
+    $array `[` $index_attr `]` attr-dict
+    `:` qualified(type($array)) `->` qualified(type($result))
+  }];
+
+  let hasVerifier = 1;
+}
+
 def BIR_AllocHeapOp : BIR_Op<"alloc_heap", [
   TypesMatchWith<"", "roots", "relocated_roots", "$_self">
 ]> {

--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -25,7 +25,8 @@ def BIR_AnyType : AnyTypeOf<[
   BIR_StringType,
   FunctionType,
   BIR_BoolType,
-  BIR_StructType
+  BIR_StructType,
+  BIR_ArrayType
 ]>;
 
 def BIR_ConstantOp : BIR_Op<"constant", [

--- a/include/belalang/BIR/IR/BIRTypes.td
+++ b/include/belalang/BIR/IR/BIRTypes.td
@@ -60,6 +60,18 @@ def BIR_StructType : BIR_Type<"Struct", "struct", [
 
 }
 
+def BIR_ArrayType : BIR_Type<"Array", "array", [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+]> {
+  let summary = "Array type";
+
+  let parameters = (ins
+    ArrayRefParameter<"mlir::Type", "">:$members
+  );
+
+  let assemblyFormat = "`<` `[` $members `]` `>`";
+}
+
 def BIR_ReferencableType : AnyTypeOf<[
   BIR_IntType,
   BIR_FloatType,

--- a/include/belalang/BIR/IR/BIRTypes.td
+++ b/include/belalang/BIR/IR/BIRTypes.td
@@ -78,7 +78,8 @@ def BIR_ReferencableType : AnyTypeOf<[
   BIR_StringType,
   FunctionType,
   BIR_BoolType,
-  BIR_StructType
+  BIR_StructType,
+  BIR_ArrayType
 ]>;
 
 def BIR_RefType : BIR_Type<"Ref", "ref", [

--- a/lib/BIR/IR/BIRAttrs.cpp
+++ b/lib/BIR/IR/BIRAttrs.cpp
@@ -5,6 +5,8 @@
 namespace belalang {
 namespace bir {
 
+using namespace mlir;
+
 mlir::Attribute IntegerAttr::parse(mlir::AsmParser &p, mlir::Type attrType) {
   if (p.parseLess())
     return {};
@@ -68,6 +70,10 @@ void StringAttr::print(mlir::AsmPrinter &p) const {
   p << ">";
 }
 
+// -----------------------------------------------------------------------------
+// StructAttr
+// -----------------------------------------------------------------------------
+
 mlir::Attribute StructAttr::parse(mlir::AsmParser &p, mlir::Type attrType) {
   if (p.parseLess().failed())
     return {};
@@ -108,6 +114,51 @@ void StructAttr::print(mlir::AsmPrinter &p) const {
                           p.printType(getMemberTypes()[i]);
                         });
   p << "}>";
+}
+
+// -----------------------------------------------------------------------------
+// ArrayAttr
+// -----------------------------------------------------------------------------
+
+mlir::Attribute ArrayAttr::parse(mlir::AsmParser &p, mlir::Type attrType) {
+  if (p.parseLess().failed())
+    return {};
+
+  llvm::SmallVector<mlir::Attribute> members;
+  llvm::SmallVector<mlir::Type> memberTypes;
+
+  auto result =
+      p.parseCommaSeparatedList(mlir::AsmParser::Delimiter::Square, [&]() {
+        mlir::Attribute member;
+        if (p.parseAttribute(member).failed())
+          return mlir::failure();
+
+        auto typedMember = llvm::dyn_cast<mlir::TypedAttr>(member);
+        if (!typedMember)
+          return mlir::failure();
+
+        members.push_back(member);
+        memberTypes.push_back(typedMember.getType());
+        return mlir::success();
+      });
+  if (result.failed())
+    return {};
+
+  if (p.parseGreater().failed())
+    return {};
+
+  return ArrayAttr::get(p.getContext(), attrType, members, memberTypes);
+}
+
+void ArrayAttr::print(mlir::AsmPrinter &p) const {
+  p << "<[";
+  llvm::interleaveComma(llvm::seq<size_t>(0, getMembers().size()), p,
+                        [&](size_t i) {
+                          p.printAttributeWithoutType(getMembers()[i]);
+                          p << " : ";
+                          p.printType(getMemberTypes()[i]);
+                        });
+  p << "]>";
 }
 
 } // namespace bir

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -87,6 +87,19 @@ mlir::LogicalResult ConstantOp::verify() {
   return emitOpError() << "type and attribute mismatch.";
 }
 
+mlir::LogicalResult GetElementOp::verify() {
+  auto arrayType = mlir::cast<bir::ArrayType>(getArray().getType());
+  uint64_t index = getIndexAttr().getZExtValue();
+  if (index >= arrayType.getMembers().size())
+    return emitOpError() << "element index is out of bounds";
+
+  auto resultType = mlir::cast<bir::RefType>(getResult().getType());
+  if (resultType.getReferent() != arrayType.getMembers()[index])
+    return emitOpError() << "result type does not match array element type";
+
+  return mlir::success();
+}
+
 // -----------------------------------------------------------------------------
 // FuncOp
 // -----------------------------------------------------------------------------

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -80,6 +80,10 @@ mlir::LogicalResult ConstantOp::verify() {
     return mlir::success();
   }
 
+  if (mlir::isa<bir::ArrayType>(ty) && mlir::isa<bir::ArrayAttr>(attr)) {
+    return mlir::success();
+  }
+
   return emitOpError() << "type and attribute mismatch.";
 }
 

--- a/lib/BIR/IR/BIRTypes.cpp
+++ b/lib/BIR/IR/BIRTypes.cpp
@@ -287,32 +287,12 @@ StructType::getABIAlignment(const mlir::DataLayout &dl,
 llvm::TypeSize
 ArrayType::getTypeSizeInBits(const mlir::DataLayout &dl,
                            mlir::DataLayoutEntryListRef params) const {
-  unsigned arSize = 0;
-  uint64_t arAlign = 1;
-
-  for (auto ty : getMembers()) {
-    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
-
-    arSize = llvm::alignTo(arSize, tyAlign);
-    arSize += dl.getTypeSize(ty).getFixedValue();
-
-    arAlign = std::max(tyAlign, arAlign);
-  }
-
-  arSize = llvm::alignTo(arSize, arAlign);
-  return llvm::TypeSize::getFixed(arSize * 8); // in bits.
+  return dl.getTypeSizeInBits(mlir::LLVM::LLVMPointerType::get(getContext()));
 }
 
 uint64_t ArrayType::getABIAlignment(const mlir::DataLayout &dl,
                                   mlir::DataLayoutEntryListRef params) const {
-  uint64_t arAlign = 1;
-
-  for (mlir::Type ty : getMembers()) {
-    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
-    arAlign = std::max(tyAlign, arAlign);
-  }
-
-  return arAlign;
+  return dl.getTypeABIAlignment(mlir::LLVM::LLVMPointerType::get(getContext()));
 }
 
 } // namespace bir

--- a/lib/BIR/IR/BIRTypes.cpp
+++ b/lib/BIR/IR/BIRTypes.cpp
@@ -74,7 +74,7 @@ StringType::getABIAlignment(const mlir::DataLayout &dl,
 }
 
 // -----------------------------------------------------------------------------
-// StructType
+// RefType
 // -----------------------------------------------------------------------------
 
 llvm::TypeSize
@@ -89,6 +89,10 @@ uint64_t RefType::getABIAlignment(const mlir::DataLayout &dl,
   auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
   return dl.getTypeABIAlignment(ptrType);
 }
+
+// -----------------------------------------------------------------------------
+// StructType
+// -----------------------------------------------------------------------------
 
 mlir::Type StructType::parse(mlir::AsmParser &p) {
   const mlir::SMLoc loc = p.getCurrentLocation();
@@ -274,6 +278,41 @@ StructType::getABIAlignment(const mlir::DataLayout &dl,
   }
 
   return stAlign;
+}
+
+// -----------------------------------------------------------------------------
+// ArrayType
+// -----------------------------------------------------------------------------
+
+llvm::TypeSize
+ArrayType::getTypeSizeInBits(const mlir::DataLayout &dl,
+                           mlir::DataLayoutEntryListRef params) const {
+  unsigned arSize = 0;
+  uint64_t arAlign = 1;
+
+  for (auto ty : getMembers()) {
+    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
+
+    arSize = llvm::alignTo(arSize, tyAlign);
+    arSize += dl.getTypeSize(ty).getFixedValue();
+
+    arAlign = std::max(tyAlign, arAlign);
+  }
+
+  arSize = llvm::alignTo(arSize, arAlign);
+  return llvm::TypeSize::getFixed(arSize * 8); // in bits.
+}
+
+uint64_t ArrayType::getABIAlignment(const mlir::DataLayout &dl,
+                                  mlir::DataLayoutEntryListRef params) const {
+  uint64_t arAlign = 1;
+
+  for (mlir::Type ty : getMembers()) {
+    uint64_t tyAlign = dl.getTypeABIAlignment(ty);
+    arAlign = std::max(tyAlign, arAlign);
+  }
+
+  return arAlign;
 }
 
 } // namespace bir

--- a/lib/BIR/IR/BIRTypesTest.cpp
+++ b/lib/BIR/IR/BIRTypesTest.cpp
@@ -161,8 +161,8 @@ TEST_F(BIRTypesTest, EmptyArrayType) {
   auto dl = getDataLayout();
   auto ty = ArrayType::get(&context, {});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 0);
-  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
 }
 
 TEST_F(BIRTypesTest, ArrayTypeWithOnlyByteAlignedMembers) {
@@ -171,8 +171,8 @@ TEST_F(BIRTypesTest, ArrayTypeWithOnlyByteAlignedMembers) {
                            {BoolType::get(&context), BoolType::get(&context),
                             BoolType::get(&context)});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 24);
-  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
 }
 
 TEST_F(BIRTypesTest, ArrayTypeWithLeadingPadding) {
@@ -180,7 +180,7 @@ TEST_F(BIRTypesTest, ArrayTypeWithLeadingPadding) {
   auto ty = ArrayType::get(&context,
                            {BoolType::get(&context), IntType::get(&context)});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
   EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
 }
 
@@ -189,7 +189,7 @@ TEST_F(BIRTypesTest, ArrayTypeWithTrailingPadding) {
   auto ty = ArrayType::get(&context,
                            {IntType::get(&context), BoolType::get(&context)});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
   EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
 }
 
@@ -199,7 +199,7 @@ TEST_F(BIRTypesTest, ArrayTypeWithStringAndReference) {
       &context,
       {StringType::get(&context), RefType::get(&context, IntType::get(&context))});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 192);
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 64);
   EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
 }
 
@@ -210,7 +210,7 @@ TEST_F(BIRTypesTest, NestedArrayType) {
   auto outer = ArrayType::get(
       &context, {BoolType::get(&context), inner, BoolType::get(&context)});
 
-  EXPECT_EQ(dl.getTypeSizeInBits(outer).getFixedValue(), 256);
+  EXPECT_EQ(dl.getTypeSizeInBits(outer).getFixedValue(), 64);
   EXPECT_EQ(dl.getTypeABIAlignment(outer), 8);
 }
 

--- a/lib/BIR/IR/BIRTypesTest.cpp
+++ b/lib/BIR/IR/BIRTypesTest.cpp
@@ -157,6 +157,63 @@ TEST_F(BIRTypesTest, NestedStructType) {
   EXPECT_EQ(dl.getTypeABIAlignment(outer), 8);
 }
 
+TEST_F(BIRTypesTest, EmptyArrayType) {
+  auto dl = getDataLayout();
+  auto ty = ArrayType::get(&context, {});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 0);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+}
+
+TEST_F(BIRTypesTest, ArrayTypeWithOnlyByteAlignedMembers) {
+  auto dl = getDataLayout();
+  auto ty = ArrayType::get(&context,
+                           {BoolType::get(&context), BoolType::get(&context),
+                            BoolType::get(&context)});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 24);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 1);
+}
+
+TEST_F(BIRTypesTest, ArrayTypeWithLeadingPadding) {
+  auto dl = getDataLayout();
+  auto ty = ArrayType::get(&context,
+                           {BoolType::get(&context), IntType::get(&context)});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, ArrayTypeWithTrailingPadding) {
+  auto dl = getDataLayout();
+  auto ty = ArrayType::get(&context,
+                           {IntType::get(&context), BoolType::get(&context)});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 128);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, ArrayTypeWithStringAndReference) {
+  auto dl = getDataLayout();
+  auto ty = ArrayType::get(
+      &context,
+      {StringType::get(&context), RefType::get(&context, IntType::get(&context))});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(ty).getFixedValue(), 192);
+  EXPECT_EQ(dl.getTypeABIAlignment(ty), 8);
+}
+
+TEST_F(BIRTypesTest, NestedArrayType) {
+  auto dl = getDataLayout();
+  auto inner = ArrayType::get(
+      &context, {BoolType::get(&context), IntType::get(&context)});
+  auto outer = ArrayType::get(
+      &context, {BoolType::get(&context), inner, BoolType::get(&context)});
+
+  EXPECT_EQ(dl.getTypeSizeInBits(outer).getFixedValue(), 256);
+  EXPECT_EQ(dl.getTypeABIAlignment(outer), 8);
+}
+
 } // namespace
 } // namespace bir
 } // namespace belalang

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -35,22 +35,40 @@ static void collectGCPointerOffsets(mlir::Type type,
                                     const mlir::DataLayout &dataLayout,
                                     uint64_t baseOffset,
                                     llvm::SmallVectorImpl<uint32_t> &offsets) {
-  auto structType = mlir::dyn_cast<bir::StructType>(type);
-  if (!structType)
-    return;
-
   uint64_t currentOffset = 0;
-  for (int32_t logicalIndex : structType.getInverseReorder()) {
-    mlir::Type member = structType.getMembers()[logicalIndex];
+  llvm::SmallVector<mlir::Type> members;
+  if (auto structType = mlir::dyn_cast<bir::StructType>(type)) {
+    for (int32_t logicalIndex : structType.getInverseReorder())
+      members.push_back(structType.getMembers()[logicalIndex]);
+  } else if (auto arrayType = mlir::dyn_cast<bir::ArrayType>(type)) {
+    llvm::append_range(members, arrayType.getMembers());
+  } else {
+    return;
+  }
+
+  for (mlir::Type member : members) {
     uint64_t memberAlign = dataLayout.getTypeABIAlignment(member);
     currentOffset = llvm::alignTo(currentOffset, memberAlign);
-    if (mlir::isa<bir::RefType>(member))
+    if (mlir::isa<bir::RefType, bir::ArrayType>(member))
       offsets.push_back(static_cast<uint32_t>(baseOffset + currentOffset));
     else
       collectGCPointerOffsets(member, dataLayout, baseOffset + currentOffset,
                               offsets);
     currentOffset += dataLayout.getTypeSize(member).getFixedValue();
   }
+}
+
+static mlir::Type getArrayPayloadType(const mlir::TypeConverter &typeConverter,
+                                      bir::ArrayType arrayType) {
+  llvm::SmallVector<mlir::Type> members;
+  for (mlir::Type member : arrayType.getMembers()) {
+    auto converted = typeConverter.convertType(member);
+    if (!converted)
+      return {};
+    members.push_back(converted);
+  }
+  return mlir::LLVM::LLVMStructType::getLiteral(arrayType.getContext(),
+                                                members);
 }
 
 static llvm::SmallVector<uint32_t>
@@ -177,6 +195,74 @@ struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
       auto c1 = LLVM::InsertValueOp::create(rewriter, op.getLoc(), container.getType(), container, addrOfOp, rewriter.getDenseI64ArrayAttr({0}));
       rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(op, c1.getType(), c1, len, rewriter.getDenseI64ArrayAttr({1}));
 
+      return success();
+    } else if (auto arrayAttr = llvm::dyn_cast<bir::ArrayAttr>(value)) {
+      auto arrayType = mlir::cast<bir::ArrayType>(op.getType());
+      auto payloadType = getArrayPayloadType(*getTypeConverter(), arrayType);
+      if (!payloadType)
+        return failure();
+
+      auto module = op->getParentOfType<mlir::ModuleOp>();
+      auto ctx = op->getContext();
+      auto dataLayout = mlir::DataLayout::closest(op);
+      auto i64Type = mlir::IntegerType::get(ctx, 64);
+      auto ptrType = LLVM::LLVMPointerType::get(ctx);
+
+      auto allocType = LLVM::LLVMFunctionType::get(ptrType,
+                                                   {i64Type, i64Type, ptrType});
+      getOrCreateRuntimeFunction(module, op.getLoc(), kGCAllocLayout, allocType,
+                                 rewriter);
+
+      uint64_t payloadSize = dataLayout.getTypeSize(payloadType);
+      auto sizeValue = LLVM::ConstantOp::create(
+          rewriter, op.getLoc(), i64Type,
+          rewriter.getI64IntegerAttr(payloadSize));
+      auto pointerOffsets = getGCPointerOffsets(arrayType, dataLayout);
+      auto pointerCount = LLVM::ConstantOp::create(
+          rewriter, op.getLoc(), i64Type,
+          rewriter.getI64IntegerAttr(pointerOffsets.size()));
+      auto offsets = getOrCreatePointerOffsetsGlobal(
+          op.getLoc(), module, arrayType, pointerOffsets, rewriter);
+      auto allocation = LLVM::CallOp::create(
+          rewriter, op.getLoc(), ptrType,
+          FlatSymbolRefAttr::get(ctx, kGCAllocLayout),
+          ValueRange{sizeValue, pointerCount, offsets});
+
+      if (arrayAttr.getMembers().size() != arrayType.getMembers().size())
+        return failure();
+
+      for (auto [index, memberAttr, memberType] :
+           llvm::zip(llvm::seq<unsigned>(0, arrayAttr.getMembers().size()),
+                     arrayAttr.getMembers(), arrayAttr.getMemberTypes())) {
+        auto convertedType = getTypeConverter()->convertType(memberType);
+        if (!convertedType)
+          return failure();
+
+        mlir::Attribute convertedAttr;
+        if (auto intAttr = llvm::dyn_cast<bir::IntegerAttr>(memberAttr))
+          convertedAttr = rewriter.getIntegerAttr(convertedType,
+                                                  intAttr.getValue());
+        else if (auto floatAttr = llvm::dyn_cast<bir::FloatAttr>(memberAttr))
+          convertedAttr = rewriter.getFloatAttr(convertedType,
+                                                floatAttr.getValue());
+        else if (auto boolAttr = llvm::dyn_cast<bir::BoolAttr>(memberAttr))
+          convertedAttr = rewriter.getIntegerAttr(
+              convertedType, static_cast<int64_t>(boolAttr.getValue()));
+        else
+          return failure();
+
+        llvm::SmallVector<LLVM::GEPArg> indices = {0,
+                                                   static_cast<int32_t>(index)};
+        auto elementPtr = LLVM::GEPOp::create(
+            rewriter, op.getLoc(), ptrType, payloadType, allocation.getResult(),
+            indices,
+            LLVM::GEPNoWrapFlags::inbounds | LLVM::GEPNoWrapFlags::nuw);
+        auto elementValue = LLVM::ConstantOp::create(
+            rewriter, op.getLoc(), convertedType, convertedAttr);
+        LLVM::StoreOp::create(rewriter, op.getLoc(), elementValue, elementPtr);
+      }
+
+      rewriter.replaceOp(op, allocation.getResult());
       return success();
     } else if (auto structAttr = llvm::dyn_cast<bir::StructAttr>(value)) {
       auto module = op->getParentOfType<mlir::ModuleOp>();
@@ -568,7 +654,13 @@ struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> 
     // The AllocHeapOp strictly uses the RefType as the result type.
     // We're allocating memory the size of the referent.
     auto type = mlir::cast<bir::RefType>(op.getResult().getType());
-    auto referentLLVMTy = getTypeConverter()->convertType(type.getReferent());
+    mlir::Type referentLLVMTy;
+    if (auto arrayType = mlir::dyn_cast<bir::ArrayType>(type.getReferent()))
+      referentLLVMTy = getArrayPayloadType(*getTypeConverter(), arrayType);
+    else
+      referentLLVMTy = getTypeConverter()->convertType(type.getReferent());
+    if (!referentLLVMTy)
+      return failure();
     uint64_t typeSize = dataLayout.getTypeSize(referentLLVMTy);
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
@@ -866,7 +958,8 @@ struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
       mlir::MLIRContext *ctx = ty.getContext();
       mlir::Type ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
       mlir::Type iType = mlir::IntegerType::get(ctx, 64);
-      auto stringTy = mlir::LLVM::LLVMStructType::getIdentified(ctx, "bel.String");
+      auto stringTy =
+          mlir::LLVM::LLVMStructType::getIdentified(ctx, "bel.String");
       assert(stringTy.setBody({ptrType, iType}, false).succeeded());
       return stringTy;
     });
@@ -879,6 +972,9 @@ struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
       return llvmStruct;
     });
     addConversion([](bir::RefType ty) {
+      return LLVM::LLVMPointerType::get(ty.getContext());
+    });
+    addConversion([](bir::ArrayType ty) {
       return LLVM::LLVMPointerType::get(ty.getContext());
     });
     addConversion([](mlir::FunctionType type) -> mlir::Type {

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -983,6 +983,30 @@ struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
   }
 };
 
+struct GetElementOpLowering final
+    : public OpConversionPattern<bir::GetElementOp> {
+  using OpConversionPattern<bir::GetElementOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::GetElementOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto arrayType = mlir::cast<bir::ArrayType>(op.getArray().getType());
+    auto payloadType = getArrayPayloadType(*getTypeConverter(), arrayType);
+    auto resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!payloadType || !resultType)
+      return failure();
+
+    llvm::SmallVector<mlir::LLVM::GEPArg, 2> indices = {
+        0, static_cast<int32_t>(op.getIndexAttr().getZExtValue())};
+    mlir::LLVM::GEPNoWrapFlags flags =
+        mlir::LLVM::GEPNoWrapFlags::inbounds |
+        mlir::LLVM::GEPNoWrapFlags::nuw;
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+        op, resultType, payloadType, adaptor.getArray(), indices, flags);
+    return success();
+  }
+};
+
 static void insertBRTInitCall(mlir::Operation *op) {
   mlir::ModuleOp module = dyn_cast_or_null<mlir::ModuleOp>(op);
   assert(module || "unexpected non-ModuleOp");
@@ -1042,7 +1066,8 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
                ShrOpLowering, AllocHeapOpLowering, AllocStackOpLowering,
                StoreOpLowering, LoadOpLowering, CondBrLowering, CmpOpLowering,
-               GetMemberOpLowering>(typeConverter, patterns.getContext());
+               GetMemberOpLowering, GetElementOpLowering>(
+      typeConverter, patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/BIR/IR/constant-op.mlir
+++ b/tests/BIR/IR/constant-op.mlir
@@ -70,6 +70,14 @@ bir.func @structstruct() {
 
 // -----
 
+bir.func @arrayarray() {
+  // CHECK: bir.constant #bir.array<[#bir.int<42> : !bir.int, #bir.int<42> : !bir.int]> : !bir.array<[!bir.int, !bir.int]>
+  %0 = bir.constant #bir.array<[#bir.int<42> : !bir.int, #bir.int<42> : !bir.int]> : !bir.array<[!bir.int, !bir.int]>
+  bir.return
+}
+
+// -----
+
 bir.func @structint() {
   // expected-error@+1 {{'bir.constant' op type and attribute mismatch}}
   %0 = bir.constant #bir.struct<{#bir.int<42> : !bir.int}> : !bir.int

--- a/tests/BIR/IR/get-element-op.mlir
+++ b/tests/BIR/IR/get-element-op.mlir
@@ -1,0 +1,18 @@
+// RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
+
+// CHECK: bir.func @f(%[[ARRAY:.*]]: !bir.array<[!bir.int, !bir.float]>)
+// CHECK: bir.get_element %[[ARRAY]][0] : !bir.array<[!bir.int, !bir.float]> -> !bir.ref<!bir.int>
+bir.func @f(%0: !bir.array<[!bir.int, !bir.float]>) {
+  %1 = bir.get_element %0[0]
+      : !bir.array<[!bir.int, !bir.float]> -> !bir.ref<!bir.int>
+  bir.return
+}
+
+// -----
+
+// expected-error@+2 {{element index is out of bounds}}
+bir.func @out_of_bounds(%0: !bir.array<[!bir.int]>) {
+  %1 = bir.get_element %0[1]
+      : !bir.array<[!bir.int]> -> !bir.ref<!bir.int>
+  bir.return
+}

--- a/tests/BIR/Target/LLVMIR/array.mlir
+++ b/tests/BIR/Target/LLVMIR/array.mlir
@@ -1,0 +1,14 @@
+// RUN: %bir-opt --split-input-file --bir-lowering-pipeline %s \
+// RUN: | %bir-translate --bir-to-llvmir \
+// RUN: | %FileCheck %s
+
+// CHECK: define ptr @array() {
+// CHECK: call ptr @brt_gc_alloc_layout(i64 16, i64 0, ptr null)
+// CHECK: store i64 42
+// CHECK: store i64 41
+// CHECK: ret ptr
+
+bir.func @array() -> !bir.array<[!bir.int, !bir.int]> {
+  %0 = bir.constant #bir.array<[#bir.int<42> : !bir.int, #bir.int<41> : !bir.int]> : !bir.array<[!bir.int, !bir.int]>
+  bir.return %0 : !bir.array<[!bir.int, !bir.int]>
+}

--- a/tests/BIR/Target/LLVMIR/gc-layout.mlir
+++ b/tests/BIR/Target/LLVMIR/gc-layout.mlir
@@ -12,3 +12,15 @@ bir.func @main() {
   %0 = bir.alloc_heap : !bir.ref<!bir.struct<"Box", {!bir.int, !bir.ref<!bir.int>}>>
   bir.return
 }
+
+// -----
+
+// CHECK-DAG: @gc.ptr_offsets.{{.*}} = private constant [1 x i32] zeroinitializer
+// CHECK-LABEL: define void @array_field() {
+// CHECK: call ptr @brt_gc_alloc_layout(i64 8, i64 1, ptr @gc.ptr_offsets.{{.*}})
+// CHECK: ret void
+
+bir.func @array_field() {
+  %0 = bir.alloc_heap : !bir.ref<!bir.struct<"ArrayBox", {!bir.array<[!bir.int, !bir.int]>}>>
+  bir.return
+}

--- a/tests/BIR/Transforms/BIRToLLVM/array-attr.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/array-attr.mlir
@@ -1,0 +1,27 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+// CHECK-LABEL: llvm.func @f() -> !llvm.ptr
+// CHECK: llvm.call @brt_gc_alloc_layout
+// CHECK: llvm.getelementptr inbounds|nuw {{.*}}[0, 0]
+// CHECK: llvm.store {{.*}} : i64, !llvm.ptr
+// CHECK: llvm.getelementptr inbounds|nuw {{.*}}[0, 1]
+// CHECK: llvm.store {{.*}} : i64, !llvm.ptr
+// CHECK: llvm.return {{.*}} : !llvm.ptr
+
+bir.func @f() -> !bir.array<[!bir.int, !bir.int]> {
+  %0 = bir.constant #bir.array<[#bir.int<42> : !bir.int, #bir.int<41> : !bir.int]> : !bir.array<[!bir.int, !bir.int]>
+  bir.return %0 : !bir.array<[!bir.int, !bir.int]>
+}
+
+// -----
+
+// CHECK: llvm.func @f() -> !llvm.ptr
+// CHECK: llvm.call @brt_gc_alloc_layout
+// CHECK: llvm.store {{.*}} : i64, !llvm.ptr
+// CHECK: llvm.store {{.*}} : f64, !llvm.ptr
+// CHECK: llvm.return {{.*}} : !llvm.ptr
+
+bir.func @f() -> !bir.array<[!bir.int, !bir.float]> {
+  %0 = bir.constant #bir.array<[#bir.int<42> : !bir.int, #bir.float<4.0> : !bir.float]> : !bir.array<[!bir.int, !bir.float]>
+  bir.return %0 : !bir.array<[!bir.int, !bir.float]>
+}

--- a/tests/BIR/Transforms/BIRToLLVM/get-element-op.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/get-element-op.mlir
@@ -1,0 +1,10 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+// CHECK-LABEL: llvm.func @f
+// CHECK: llvm.getelementptr inbounds|nuw %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f64)>
+
+bir.func @f(%0: !bir.array<[!bir.int, !bir.float]>) {
+  %1 = bir.get_element %0[0]
+      : !bir.array<[!bir.int, !bir.float]> -> !bir.ref<!bir.int>
+  bir.return
+}


### PR DESCRIPTION
This initial implementation adds immutable arrays and a way to get their elements using `get_element` op. 