### PR TITLE
[bir][FuncOp] Add private for externally linked functions

### DIFF
--- a/include/belalang/BIR/IR/BIROps.td
+++ b/include/belalang/BIR/IR/BIROps.td
@@ -230,6 +230,9 @@ def BIR_FuncOp : BIR_Op<"func", [FunctionOpInterface, CallableOpInterface,
 
     ::llvm::ArrayRef<::mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
 
+    // An empty body is the BIR representation of an external declaration.
+    bool isDeclaration() { return getBody().empty(); }
+
     mlir::Type getResType();
   }];
 

--- a/lib/BIR/IR/BIROps.cpp
+++ b/lib/BIR/IR/BIROps.cpp
@@ -143,6 +143,15 @@ mlir::LogicalResult FuncOp::verify() {
   if (getFunctionType().getNumResults() > 1)
     return emitOpError() << "supports at most one result";
 
+  // MLIR declarations are only visible within the current symbol table. The
+  // generated LLVM declaration remains externally linked; this is the same
+  // distinction used by CIR for runtime and other imported functions.
+  if (isDeclaration() &&
+      mlir::SymbolTable::getSymbolVisibility(getOperation()) !=
+          mlir::SymbolTable::Visibility::Private)
+    return emitOpError()
+           << "function declarations must have private visibility";
+
   return mlir::success();
 }
 

--- a/lib/BIR/Transforms/BIRToLLVM.cpp
+++ b/lib/BIR/Transforms/BIRToLLVM.cpp
@@ -345,6 +345,10 @@ struct FuncOpLowering final : public OpConversionPattern<bir::FuncOp> {
     auto llvmFuncOp = LLVM::LLVMFuncOp::create(rewriter, op.getLoc(),
                                                op.getName(), llvmFuncType);
 
+    // An empty private BIR function is an external declaration.
+    if (op.isDeclaration())
+      llvmFuncOp.setLinkage(LLVM::Linkage::External);
+
     rewriter.inlineRegionBefore(op.getBody(), llvmFuncOp.getBody(),
                                 llvmFuncOp.end());
     if (failed(rewriter.convertRegionTypes(

--- a/tests/BIR/IR/error-func-declaration.mlir
+++ b/tests/BIR/IR/error-func-declaration.mlir
@@ -1,0 +1,4 @@
+// RUN: %not %bir-opt --verify-diagnostics %s 2>&1 | %FileCheck %s
+
+// CHECK: error: 'bir.func' op symbol declaration cannot have public visibility
+bir.func @public_declaration()

--- a/tests/BIR/IR/func.mlir
+++ b/tests/BIR/IR/func.mlir
@@ -45,11 +45,11 @@ bir.func @f(%arg0 : !bir.int) -> (!bir.int, !bir.int) {
 
 // -----
 
-// CHECK: bir.func @f(!bir.int) -> !bir.int
-// CHECK: bir.func @g(!bir.int)
+// CHECK: bir.func private @f(!bir.int) -> !bir.int
+// CHECK: bir.func private @g(!bir.int)
 
-bir.func @f(%arg0 : !bir.int) -> !bir.int
-bir.func @g(%arg0 : !bir.int)
+bir.func private @f(%arg0 : !bir.int) -> !bir.int
+bir.func private @g(%arg0 : !bir.int)
 
 // CHECK:      bir.func @main() -> !bir.int {
 // CHECK-NEXT:   %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int

--- a/tests/BIR/IR/while-op.mlir
+++ b/tests/BIR/IR/while-op.mlir
@@ -1,6 +1,6 @@
 // RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @main() {
   // CHECK: bir.while

--- a/tests/BIR/Transforms/BIRToLLVM/cmp-op.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/cmp-op.mlir
@@ -1,6 +1,6 @@
 // RUN: %bir-opt --split-input-file --bir-lowering-pipeline --convert-bir-to-llvm %s | %FileCheck %s
 
-bir.func @use_bool(!bir.bool)
+bir.func private @use_bool(!bir.bool)
 
 bir.func @main() {
   // CHECK: %[[C0:.*]] = llvm.mlir.constant(0 : i64) : i64
@@ -39,7 +39,7 @@ bir.func @main() {
 
 // -----
 
-bir.func @use_bool(!bir.bool)
+bir.func private @use_bool(!bir.bool)
 
 bir.func @main() {
   // CHECK: %[[C0:.*]] = llvm.mlir.constant(0.000000e+00 : f64) : f64

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -45,8 +45,8 @@ bir.func @main() {
 // CHECK: llvm.call @f(%[[C1]]) : (i64) -> i64
 // CHECK: llvm.return %[[CALL]] : i64
 
-bir.func @f(%arg0 : !bir.int) -> !bir.int
-bir.func @g(%arg0 : !bir.int)
+bir.func private @f(%arg0 : !bir.int) -> !bir.int
+bir.func private @g(%arg0 : !bir.int)
 
 bir.func @main() -> !bir.int {
   %0 = bir.constant #bir.int<1> : !bir.int
@@ -83,7 +83,7 @@ bir.func @main() -> !bir.int {
 // CHECK-LABEL: llvm.func @main()
 // CHECK-NEXT:   %[[ADDR:.*]] = llvm.mlir.addressof @f : !llvm.ptr
 // CHECK-NEXT:   llvm.return
-bir.func @f()
+bir.func private @f()
 
 bir.func @main() {
   %0 = bir.constant #bir.fn<@f> : () -> ()

--- a/tests/BIR/Transforms/CSE/pipeline.mlir
+++ b/tests/BIR/Transforms/CSE/pipeline.mlir
@@ -6,7 +6,7 @@
 // CHECK: bir.call @use(%[[SUM]])
 // CHECK: bir.call @use(%[[SUM]])
 // CHECK: bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @merges_duplicate_pure_work() {
   %0 = bir.constant #bir.int<1> : !bir.int

--- a/tests/BIR/Transforms/DCE/trivial-dce.mlir
+++ b/tests/BIR/Transforms/DCE/trivial-dce.mlir
@@ -44,9 +44,9 @@ bir.func @unused_get_member() {
 // CHECK: bir.call @callee(%[[ZERO]]) : (!bir.int) -> ()
 // CHECK: %[[HEAP:.*]], %[[RELOCATED:.*]] = bir.alloc_heap : !bir.ref<!bir.int> roots(%[[STACK]] : !bir.ref<!bir.int>)
 // CHECK: bir.return
-bir.func @callee(!bir.int)
+bir.func private @callee(!bir.int)
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @retain_effectful_ops() {
   %0 = bir.constant #bir.int<0> : !bir.int
@@ -80,7 +80,7 @@ bir.func @unused_bitwise_and_cmp() {
 // CHECK-LABEL: bir.func @unreachable_blocks
 // CHECK-NEXT: bir.return
 // CHECK-NEXT: }
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @unreachable_blocks() {
   bir.return

--- a/tests/BIR/Transforms/FlattenCFG/if-op.mlir
+++ b/tests/BIR/Transforms/FlattenCFG/if-op.mlir
@@ -13,7 +13,7 @@
 // CHECK-NEXT: ^bb3:  // 2 preds: ^bb1, ^bb2
 // CHECK-NEXT:   bir.return
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @main() {
   %0 = bir.constant #bir.bool<true> : !bir.bool
@@ -40,7 +40,7 @@ bir.func @main() {
 // CHECK-NEXT: ^bb2:  // 2 preds: ^bb0, ^bb1
 // CHECK-NEXT:   bir.return
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @main() {
   %0 = bir.constant #bir.bool<true> : !bir.bool
@@ -65,7 +65,7 @@ bir.func @main() {
 // CHECK-NEXT: ^bb3(%3: !bir.int):  // 2 preds: ^bb1, ^bb2
 // CHECK-NEXT:   bir.return
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @main() {
   %0 = bir.constant #bir.bool<true> : !bir.bool

--- a/tests/BIR/Transforms/FlattenCFG/while-op.mlir
+++ b/tests/BIR/Transforms/FlattenCFG/while-op.mlir
@@ -11,7 +11,7 @@
 // CHECK-NEXT: ^bb3:  // pred: ^bb1
 // CHECK-NEXT:   bir.return
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @main() {
   bir.while {

--- a/tests/BIR/Transforms/Mem2Reg/cfg.mlir
+++ b/tests/BIR/Transforms/Mem2Reg/cfg.mlir
@@ -12,7 +12,7 @@
 // CHECK:     ^bb3(%[[JOIN:.*]]: !bir.int):
 // CHECK:       call @use(%[[JOIN]]) : (!bir.int) -> ()
 // CHECK-NEXT:  bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @if_join() {
   %0 = bir.alloc_stack : !bir.ref<!bir.int>
@@ -45,7 +45,7 @@ bir.func @if_join() {
 // CHECK:     ^bb3:
 // CHECK:       call @use(%[[ITER]]) : (!bir.int) -> ()
 // CHECK-NEXT:  bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @loop_carried() {
   %0 = bir.alloc_stack : !bir.ref<!bir.int>

--- a/tests/BIR/Transforms/Mem2Reg/mem2reg.mlir
+++ b/tests/BIR/Transforms/Mem2Reg/mem2reg.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT:  %[[VALUE:.*]] = bir.constant #bir.int<42> : !bir.int
 // CHECK-NEXT:  call @use(%[[VALUE]]) : (!bir.int) -> ()
 // CHECK-NEXT:  bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @straight() {
   %0 = bir.alloc_stack : !bir.ref<!bir.int>
@@ -21,7 +21,7 @@ bir.func @straight() {
 // CHECK-NEXT:  %[[ZERO:.*]] = bir.constant #bir.int<0> : !bir.int
 // CHECK-NEXT:  call @use(%[[ZERO]]) : (!bir.int) -> ()
 // CHECK-NEXT:  bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @default_load() {
   %0 = bir.alloc_stack : !bir.ref<!bir.int>
@@ -39,7 +39,7 @@ bir.func @default_load() {
 // CHECK-NEXT:  %[[LOAD:.*]] = bir.load %[[HEAP]] : (!bir.ref<!bir.int>) -> !bir.int
 // CHECK-NEXT:  call @use(%[[LOAD]]) : (!bir.int) -> ()
 // CHECK-NEXT:  bir.return
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @heap_not_promoted() {
   %0 = bir.alloc_heap : !bir.ref<!bir.int>

--- a/tests/BIR/Transforms/VerifyLoweredForm/pipeline.mlir
+++ b/tests/BIR/Transforms/VerifyLoweredForm/pipeline.mlir
@@ -5,7 +5,7 @@
 // CHECK-NOT: unexpected high-level BIR operation
 // CHECK-NOT: bir.if
 
-bir.func @use(!bir.int)
+bir.func private @use(!bir.int)
 
 bir.func @pipeline() {
   %0 = bir.constant #bir.int<1> : !bir.int

--- a/tests/BIRGen/print.bel
+++ b/tests/BIRGen/print.bel
@@ -1,5 +1,6 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
+# CHECK:       bir.func private @brt_print_int(!bir.int)
 # CHECK-LABEL:bir.func @main() -> !bir.int {
 # CHECK-NEXT:   %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:   call @brt_print_int(%[[C0]]) : (!bir.int) -> ()


### PR DESCRIPTION
This closely follows ClangIR.

```mlir
cir.func private @printf(!cir.ptr<!s8i> {llvm.noundef}, ...) -> !s32i
```

The code snippet above is the result of calling printf in a ClangIR representation. The function has a private visibility. We follow that here for BIR.