### PR TITLE
[chore][CMake] Add experimental CMake build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ rust-project.json
 
 # bazel symlinks
 /bazel-*
+
+# Machine-local CMake configuration
+/CMakeUserPresets.json
+
+/build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(Belalang VERSION 0.0.0 LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+option(BELALANG_BUILD_TESTS "Build unit and lit tests" ON)
+option(BELALANG_BUILD_TOOLS "Build developer tools" ON)
+set(BELALANG_LLVM_BUILD_DIR "" CACHE PATH
+  "Path to an llvm-project build directory containing LLVM and MLIR")
+
+if(NOT BELALANG_LLVM_BUILD_DIR)
+  message(FATAL_ERROR "Set BELALANG_LLVM_BUILD_DIR to an llvm-project build directory")
+endif()
+cmake_path(ABSOLUTE_PATH BELALANG_LLVM_BUILD_DIR NORMALIZE)
+
+set(LLVM_DIR "${BELALANG_LLVM_BUILD_DIR}/lib/cmake/llvm")
+set(MLIR_DIR "${BELALANG_LLVM_BUILD_DIR}/lib/cmake/mlir")
+if(NOT EXISTS "${LLVM_DIR}/LLVMConfig.cmake" OR
+   NOT EXISTS "${MLIR_DIR}/MLIRConfig.cmake")
+  message(FATAL_ERROR
+    "BELALANG_LLVM_BUILD_DIR must contain lib/cmake/llvm/LLVMConfig.cmake "
+    "and lib/cmake/mlir/MLIRConfig.cmake")
+endif()
+
+find_package(ZLIB REQUIRED)
+find_package(LibXml2 REQUIRED)
+find_package(LLVM REQUIRED CONFIG)
+find_package(MLIR REQUIRED CONFIG)
+
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}" "${MLIR_CMAKE_DIR}")
+message(STATUS "Using LLVM/MLIR build: ${BELALANG_LLVM_BUILD_DIR}")
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+
+include(AddLLVM)
+include(AddMLIR)
+include(TableGen)
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${MLIR_INCLUDE_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+if(NOT LLVM_ENABLE_RTTI)
+  add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>")
+endif()
+if(NOT LLVM_ENABLE_EH)
+  add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>")
+endif()
+
+include(FetchContent)
+
+find_package(muopt CONFIG QUIET)
+if(NOT muopt_FOUND)
+  FetchContent_Declare(
+    muopt
+    GIT_REPOSITORY https://github.com/secona/muopt.git
+    GIT_TAG b132583b93025d23871faf237578f266e798315a
+    GIT_SHALLOW FALSE
+  )
+  FetchContent_MakeAvailable(muopt)
+endif()
+
+include(CTest)
+if(BUILD_TESTING AND BELALANG_BUILD_TESTS)
+  find_package(GTest CONFIG QUIET)
+  if(NOT GTest_FOUND)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG v1.18.0
+    )
+    FetchContent_MakeAvailable(googletest)
+  endif()
+endif()
+
+set(BELALANG_SOURCE_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/include")
+set(BELALANG_GENERATED_INCLUDE_DIR "${PROJECT_BINARY_DIR}/include")
+file(MAKE_DIRECTORY "${BELALANG_GENERATED_INCLUDE_DIR}/belalang")
+include_directories(
+  "${BELALANG_SOURCE_INCLUDE_DIR}"
+  "${BELALANG_GENERATED_INCLUDE_DIR}"
+)
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(brt)
+if(BELALANG_BUILD_TOOLS)
+  add_subdirectory(tools)
+endif()
+add_subdirectory(bin)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(belalang)

--- a/bin/belalang/CMakeLists.txt
+++ b/bin/belalang/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(belalang
+  belalang.cpp
+  CmdBuild.cpp
+  CmdRun.cpp
+  CmdVersion.cpp
+)
+target_link_libraries(belalang
+  PRIVATE
+    BelalangAST
+    BelalangBIR
+    BelalangBIRGen
+    BelalangDiag
+    BelalangLLVMGen
+    BelalangLexer
+    muopt
+)

--- a/brt/CMakeLists.txt
+++ b/brt/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(src)

--- a/brt/src/CMakeLists.txt
+++ b/brt/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(brt
+  brt.c
+  gc.c
+  llvm_stackmap.c
+)
+target_include_directories(brt PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
+if(BUILD_TESTING AND BELALANG_BUILD_TESTS)
+  file(GLOB TEST_SOURCES "*_test.cpp")
+
+  foreach(TEST_SOURCE ${TEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+    add_executable(${TEST_NAME} ${TEST_SOURCE})
+    target_link_libraries(${TEST_NAME} PRIVATE brt GTest::gtest_main)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+  endforeach()
+endif()

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,39 @@
               pkgs.python313
               pkgs.clang-tools
               pkgs.just
+              pkgs.stdenv.cc.cc.lib
             ];
             profile = ''
               export BRT_DIR="$PWD/bazel-bin/brt"
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+                pkgs.stdenv.cc.cc.lib
+              ]}:''${LD_LIBRARY_PATH:-}"
+            '';
+          }).env;
+
+          devShells.cmake = (pkgs.buildFHSEnv {
+            name = "belalang-cmake";
+            targetPkgs = pkgs: [
+              pkgs.cmake
+              pkgs.ninja
+              pkgs.clang
+              pkgs.clang-tools
+              pkgs.lld
+              pkgs.git
+              pkgs.pkg-config
+              pkgs.python313
+              pkgs.zlib
+              pkgs.zlib.dev
+              pkgs.libxml2
+              pkgs.libxml2.dev
+            ];
+            profile = ''
+              export BRT_DIR="$PWD/build/brt/src"
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+                pkgs.zlib
+                pkgs.libxml2
+                pkgs.stdenv.cc.cc.lib
+              ]}:''${LD_LIBRARY_PATH:-}"
             '';
           }).env;
         };

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(belalang)

--- a/include/belalang/BIR/CMakeLists.txt
+++ b/include/belalang/BIR/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(IR)
+add_subdirectory(Interfaces)
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(BelalangBIRPassIncGen)

--- a/include/belalang/BIR/IR/CMakeLists.txt
+++ b/include/belalang/BIR/IR/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS BIRDialect.td)
+mlir_tablegen(BIRDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(BIRDialect.cpp.inc -gen-dialect-defs)
+
+set(LLVM_TARGET_DEFINITIONS BIRTypes.td)
+mlir_tablegen(BIRTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(BIRTypes.cpp.inc -gen-typedef-defs)
+
+set(LLVM_TARGET_DEFINITIONS BIRAttrs.td)
+mlir_tablegen(BIRAttrs.h.inc -gen-attrdef-decls)
+mlir_tablegen(BIRAttrs.cpp.inc -gen-attrdef-defs)
+
+set(LLVM_TARGET_DEFINITIONS BIROps.td)
+mlir_tablegen(BIROps.h.inc -gen-op-decls)
+mlir_tablegen(BIROps.cpp.inc -gen-op-defs)
+mlir_tablegen(BIREnumAttrs.h.inc -gen-enum-decls)
+mlir_tablegen(BIREnumAttrs.cpp.inc -gen-enum-defs)
+
+add_mlir_dialect_tablegen_target(BelalangBIRIncGen)

--- a/include/belalang/BIR/Interfaces/CMakeLists.txt
+++ b/include/belalang/BIR/Interfaces/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(LLVM_TARGET_DEFINITIONS LoopOpInterface.td)
+mlir_tablegen(LoopOpInterface.h.inc -gen-op-interface-decls)
+mlir_tablegen(LoopOpInterface.cpp.inc -gen-op-interface-defs)
+add_mlir_generic_tablegen_target(BelalangBIRLoopOpInterfaceIncGen)

--- a/include/belalang/CMakeLists.txt
+++ b/include/belalang/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_subdirectory(BIR)
+add_subdirectory(GCIR)
+
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  OUTPUT_VARIABLE BELALANG_GIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+if(NOT BELALANG_GIT_HASH)
+  set(BELALANG_GIT_HASH unknown)
+endif()
+set(GIT_HASH "${BELALANG_GIT_HASH}")
+
+configure_file(Version.h.inc.in "${CMAKE_CURRENT_BINARY_DIR}/Version.h.inc" @ONLY)

--- a/include/belalang/GCIR/CMakeLists.txt
+++ b/include/belalang/GCIR/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/include/belalang/GCIR/IR/CMakeLists.txt
+++ b/include/belalang/GCIR/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(LLVM_TARGET_DEFINITIONS GCIRDialect.td)
+mlir_tablegen(GCIRDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(GCIRDialect.cpp.inc -gen-dialect-defs)
+
+set(LLVM_TARGET_DEFINITIONS GCIRTypes.td)
+mlir_tablegen(GCIRTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(GCIRTypes.cpp.inc -gen-typedef-defs)
+
+add_mlir_dialect_tablegen_target(BelalangGCIRIncGen)

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(BelalangAST
+  ASTContext.cpp
+  ASTDumper.cpp
+  Parser.cpp
+)
+target_link_libraries(BelalangAST
+  PUBLIC
+    BelalangLexer
+    BelalangDiag
+    LLVMSupport
+)

--- a/lib/BIR/Analysis/CMakeLists.txt
+++ b/lib/BIR/Analysis/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(BelalangBIR PRIVATE EscapeAnalysis.cpp)

--- a/lib/BIR/CMakeLists.txt
+++ b/lib/BIR/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_library(BelalangBIR)
+add_dependencies(BelalangBIR
+  BelalangBIRIncGen
+  BelalangBIRLoopOpInterfaceIncGen
+  BelalangBIRPassIncGen
+)
+target_link_libraries(BelalangBIR PUBLIC
+  MLIRAnalysis
+  MLIRControlFlowDialect
+  MLIRControlFlowToLLVM
+  MLIRFuncDialect
+  MLIRIR
+  MLIRLLVMDialect
+  MLIRMemorySlotInterfaces
+  MLIRPass
+  MLIRSupport
+  MLIRTransformUtils
+  MLIRTransforms
+)
+
+add_subdirectory(Analysis)
+add_subdirectory(IR)
+add_subdirectory(Interfaces)
+add_subdirectory(Transforms)

--- a/lib/BIR/IR/CMakeLists.txt
+++ b/lib/BIR/IR/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_sources(BelalangBIR PRIVATE BIRAttrs.cpp BIRDialect.cpp BIROps.cpp BIRTypes.cpp)
+
+if(BUILD_TESTING AND BELALANG_BUILD_TESTS)
+  add_executable(BelalangBIRTypesTest BIRTypesTest.cpp)
+  target_link_libraries(BelalangBIRTypesTest PRIVATE BelalangBIR GTest::gtest_main)
+  add_test(NAME BelalangBIRTypesTest COMMAND BelalangBIRTypesTest)
+endif()

--- a/lib/BIR/Interfaces/CMakeLists.txt
+++ b/lib/BIR/Interfaces/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(BelalangBIR PRIVATE LoopOpInterface.cpp)

--- a/lib/BIR/Transforms/CMakeLists.txt
+++ b/lib/BIR/Transforms/CMakeLists.txt
@@ -1,0 +1,16 @@
+target_sources(BelalangBIR PRIVATE
+  BIRToLLVM.cpp
+  FlattenCFG.cpp
+  LowerDeclToMemory.cpp
+  LowerFuncExpr.cpp
+  OptimizeStructLayout.cpp
+  PrepareGCAllocations.cpp
+  VerifyLoweredForm.cpp
+  ../Pipelines.cpp
+)
+
+if(BUILD_TESTING AND BELALANG_BUILD_TESTS)
+  add_executable(BelalangOptimizeStructLayoutTest OptimizeStructLayoutTest.cpp)
+  target_link_libraries(BelalangOptimizeStructLayoutTest PRIVATE BelalangBIR GTest::gtest_main)
+  add_test(NAME BelalangOptimizeStructLayoutTest COMMAND BelalangOptimizeStructLayoutTest)
+endif()

--- a/lib/BIRGen/CMakeLists.txt
+++ b/lib/BIRGen/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(BelalangBIRGen
+  BIRGen.cpp
+  TypeChecker.cpp
+)
+target_link_libraries(BelalangBIRGen
+  PUBLIC
+    BelalangAST
+    BelalangBIR
+    BelalangDiag
+    BelalangLexer
+    MLIRIR
+    MLIRLLVMDialect
+    MLIRPass
+    MLIRSupport
+)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(AST)
+add_subdirectory(BIR)
+add_subdirectory(BIRGen)
+add_subdirectory(Diag)
+add_subdirectory(GCIR)
+add_subdirectory(Lexer)
+add_subdirectory(LLVMGen)

--- a/lib/Diag/CMakeLists.txt
+++ b/lib/Diag/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(BelalangDiag Diag.cpp)
+target_link_libraries(BelalangDiag PUBLIC LLVMSupport)
+
+if(BUILD_TESTING AND BELALANG_BUILD_TESTS)
+  add_executable(BelalangDiagTest DiagTest.cpp)
+  target_link_libraries(BelalangDiagTest PRIVATE BelalangDiag GTest::gtest_main)
+  add_test(NAME BelalangDiagTest COMMAND BelalangDiagTest)
+endif()

--- a/lib/GCIR/CMakeLists.txt
+++ b/lib/GCIR/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(BelalangGCIR)
+add_dependencies(BelalangGCIR BelalangGCIRIncGen)
+target_link_libraries(BelalangGCIR
+  PUBLIC
+    MLIRIR
+)
+
+add_subdirectory(IR)

--- a/lib/GCIR/IR/CMakeLists.txt
+++ b/lib/GCIR/IR/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(BelalangGCIR PRIVATE GCIRDialect.cpp)

--- a/lib/LLVMGen/CMakeLists.txt
+++ b/lib/LLVMGen/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_library(BelalangLLVMGen LLVMGen.cpp)
+target_link_libraries(BelalangLLVMGen
+  PUBLIC
+    BelalangBIR
+    LLVMCodeGen
+    LLVMCore
+    LLVMInstrumentation
+    LLVMipo
+    LLVMMC
+    LLVMPasses
+    LLVMSupport
+    LLVMTarget
+    LLVMTargetParser
+    LLVMX86AsmParser
+    LLVMX86CodeGen
+    LLVMX86Desc
+    LLVMX86Info
+    MLIRBuiltinToLLVMIRTranslation
+    MLIRIR
+    MLIRLLVMDialect
+    MLIRLLVMToLLVMIRTranslation
+    MLIRPass
+    MLIRTargetLLVMIRExport
+)

--- a/lib/Lexer/CMakeLists.txt
+++ b/lib/Lexer/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(BelalangLexer Lexer.cpp)
+target_link_libraries(BelalangLexer
+  PUBLIC
+    BelalangDiag
+    LLVMSupport
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(bir-opt)
+add_subdirectory(bir-tblgen)
+add_subdirectory(bir-translate)

--- a/tools/bir-opt/CMakeLists.txt
+++ b/tools/bir-opt/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(bir-opt bir-opt.cpp)
+target_link_libraries(bir-opt
+  PRIVATE
+    BelalangBIR
+    BelalangGCIR
+    MLIRLLVMDialect
+    MLIROptLib
+)

--- a/tools/bir-tblgen/CMakeLists.txt
+++ b/tools/bir-tblgen/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(bir-tblgen bir-tblgen.cpp)
+target_link_libraries(bir-tblgen
+  PRIVATE
+    BelalangBIR
+    LLVMTableGen
+    MLIRTableGen
+)

--- a/tools/bir-translate/CMakeLists.txt
+++ b/tools/bir-translate/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(bir-translate bir-translate.cpp)
+target_link_libraries(bir-translate
+  PRIVATE
+    BelalangBIR
+    MLIRBuiltinToLLVMIRTranslation
+    MLIRLLVMDialect
+    MLIRLLVMToLLVMIRTranslation
+    MLIRTranslateLib
+)


### PR DESCRIPTION
Experiments on CMake as an alternative to Bazel. The CMake configuration is not ready to be the main build system as tests still use Bazel.