### PR TITLE
[gcir] Implement AllocOp and lowering to LLVM

### DIFF
--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -194,7 +194,9 @@ cc_library(
         ":BelalangGCIRDialectGen",
         ":BelalangGCIROpGen",
         ":BelalangGCIRTypeGen",
+        ":BelalangGCIRPassIncGen",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
     ],
 )
 
@@ -204,10 +206,12 @@ td_library(
         "belalang/GCIR/IR/GCIRDialect.td",
         "belalang/GCIR/IR/GCIRTypes.td",
         "belalang/GCIR/IR/GCIROps.td",
+        "belalang/GCIR/Transforms/Passes.td",
     ],
     includes = ["."],
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
     ],
 )
 
@@ -241,6 +245,16 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "belalang/GCIR/IR/GCIRTypes.td",
+    deps = [":BelalangGCIRTdFiles"],
+)
+
+gentbl_cc_library(
+    name = "BelalangGCIRPassIncGen",
+    tbl_outs = [
+        (["-gen-pass-decls"], "belalang/GCIR/Transforms/Passes.h.inc"),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "belalang/GCIR/Transforms/Passes.td",
     deps = [":BelalangGCIRTdFiles"],
 )
 

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -192,6 +192,7 @@ cc_library(
     includes = ["."],
     deps = [
         ":BelalangGCIRDialectGen",
+        ":BelalangGCIROpGen",
         ":BelalangGCIRTypeGen",
         "@llvm-project//mlir:IR",
     ],
@@ -202,6 +203,7 @@ td_library(
     srcs = [
         "belalang/GCIR/IR/GCIRDialect.td",
         "belalang/GCIR/IR/GCIRTypes.td",
+        "belalang/GCIR/IR/GCIROps.td",
     ],
     includes = ["."],
     deps = [
@@ -217,6 +219,17 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "belalang/GCIR/IR/GCIRDialect.td",
+    deps = [":BelalangGCIRTdFiles"],
+)
+
+gentbl_cc_library(
+    name = "BelalangGCIROpGen",
+    tbl_outs = [
+        (["-gen-op-decls"], "belalang/GCIR/IR/GCIROps.h.inc"),
+        (["-gen-op-defs"], "belalang/GCIR/IR/GCIROps.cpp.inc"),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "belalang/GCIR/IR/GCIROps.td",
     deps = [":BelalangGCIRTdFiles"],
 )
 

--- a/include/belalang/GCIR/CMakeLists.txt
+++ b/include/belalang/GCIR/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/include/belalang/GCIR/IR/CMakeLists.txt
+++ b/include/belalang/GCIR/IR/CMakeLists.txt
@@ -6,4 +6,8 @@ set(LLVM_TARGET_DEFINITIONS GCIRTypes.td)
 mlir_tablegen(GCIRTypes.h.inc -gen-typedef-decls)
 mlir_tablegen(GCIRTypes.cpp.inc -gen-typedef-defs)
 
+set(LLVM_TARGET_DEFINITIONS GCIROps.td)
+mlir_tablegen(GCIROps.h.inc -gen-op-decls)
+mlir_tablegen(GCIROps.cpp.inc -gen-op-defs)
+
 add_mlir_dialect_tablegen_target(BelalangGCIRIncGen)

--- a/include/belalang/GCIR/IR/GCIR.h
+++ b/include/belalang/GCIR/IR/GCIR.h
@@ -13,4 +13,7 @@
 #define GET_TYPEDEF_CLASSES
 #include "belalang/GCIR/IR/GCIRTypes.h.inc"
 
+#define GET_OP_CLASSES
+#include "belalang/GCIR/IR/GCIROps.h.inc"
+
 #endif // BELALANG_GCIR_IR_GCIR_H_

--- a/include/belalang/GCIR/IR/GCIROps.td
+++ b/include/belalang/GCIR/IR/GCIROps.td
@@ -1,0 +1,10 @@
+#ifndef BELALANG_GCIR_IR_GCIROPS_TD_
+#define BELALANG_GCIR_IR_GCIROPS_TD_
+
+include "belalang/GCIR/IR/GCIRDialect.td"
+include "belalang/GCIR/IR/GCIRTypes.td"
+
+class GCIR_Op<string mnemonic, list<Trait> traits = []>
+    : Op<GCIR_Dialect, mnemonic, traits> {}
+
+#endif // BELALANG_GCIR_IR_GCIROPS_TD_

--- a/include/belalang/GCIR/IR/GCIROps.td
+++ b/include/belalang/GCIR/IR/GCIROps.td
@@ -7,4 +7,15 @@ include "belalang/GCIR/IR/GCIRTypes.td"
 class GCIR_Op<string mnemonic, list<Trait> traits = []>
     : Op<GCIR_Dialect, mnemonic, traits> {}
 
+def GCIR_AllocOp : GCIR_Op<"alloc"> {
+  let results = (outs
+    GCIR_PtrType:$result
+  );
+
+  let assemblyFormat = [{
+    `:` qualified(type($result))
+    attr-dict
+  }];
+}
+
 #endif // BELALANG_GCIR_IR_GCIROPS_TD_

--- a/include/belalang/GCIR/Transforms/CMakeLists.txt
+++ b/include/belalang/GCIR/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(BelalangGCIRPassIncGen)

--- a/include/belalang/GCIR/Transforms/Passes.h
+++ b/include/belalang/GCIR/Transforms/Passes.h
@@ -1,0 +1,17 @@
+#ifndef BELALANG_GCIR_TRANSFORMS_PASSES_H_
+#define BELALANG_GCIR_TRANSFORMS_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+
+#define GEN_PASS_DECL
+#include "belalang/GCIR/Transforms/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "belalang/GCIR/Transforms/Passes.h.inc"
+
+} // namespace mlir
+
+#endif // BELALANG_GCIR_TRANSFORMS_PASSES_H_

--- a/include/belalang/GCIR/Transforms/Passes.td
+++ b/include/belalang/GCIR/Transforms/Passes.td
@@ -1,0 +1,18 @@
+#ifndef BELALANG_GCIR_TRANSFORMS_PASSES_TD_
+#define BELALANG_GCIR_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def BelalangGCIRToLLVMPass : Pass<"convert-gcir-to-llvm"> {
+  let summary = "lower gcir allocations to LLVM";
+
+  let options = [
+    Option<"allocator", "alloc-function", "std::string", "\"malloc\"",
+           "allocator function with signature ptr(i64)">
+  ];
+
+  let dependentDialects = ["::belalang::gc::GCIRDialect",
+                           "::mlir::LLVM::LLVMDialect"];
+}
+
+#endif // BELALANG_GCIR_TRANSFORMS_PASSES_TD_

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -80,6 +80,9 @@ cc_library(
     deps = [
         "//include:GCIR",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:FuncToLLVM",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:Pass",
     ],
 )
 

--- a/lib/GCIR/CMakeLists.txt
+++ b/lib/GCIR/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_library(BelalangGCIR)
-add_dependencies(BelalangGCIR BelalangGCIRIncGen)
+add_dependencies(BelalangGCIR BelalangGCIRIncGen BelalangGCIRPassIncGen)
 target_link_libraries(BelalangGCIR
   PUBLIC
     MLIRIR
+    MLIRFuncToLLVM
+    MLIRLLVMDialect
+    MLIRPass
 )
+
+target_sources(BelalangGCIR PRIVATE GCIRToLLVM.cpp)
 
 add_subdirectory(IR)

--- a/lib/GCIR/GCIRToLLVM.cpp
+++ b/lib/GCIR/GCIRToLLVM.cpp
@@ -1,0 +1,106 @@
+#include "belalang/GCIR/IR/GCIR.h"
+#include "belalang/GCIR/Transforms/Passes.h"
+
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_BELALANGGCIRTOLLVMPASS
+#include "belalang/GCIR/Transforms/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+using namespace mlir;
+using namespace belalang::gc;
+
+struct GCIRToLLVMTypeConverter final : LLVMTypeConverter {
+  explicit GCIRToLLVMTypeConverter(MLIRContext *context)
+      : LLVMTypeConverter(context) {
+    addConversion([](PtrType type) {
+      return LLVM::LLVMPointerType::get(type.getContext());
+    });
+  }
+};
+
+struct AllocOpLowering final : OpConversionPattern<AllocOp> {
+  AllocOpLowering(TypeConverter &converter, MLIRContext *context,
+                  llvm::StringRef allocator)
+      : OpConversionPattern<AllocOp>(converter, context),
+        allocator(allocator.str()) {}
+
+  LogicalResult
+  matchAndRewrite(AllocOp op, OpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return failure();
+
+    auto ptrType = cast<PtrType>(op.getResult().getType());
+    auto dataLayout = DataLayout::closest(op);
+    auto size = dataLayout.getTypeSize(ptrType.getPointee());
+    if (size.isScalable()) {
+      op.emitError("cannot lower allocation of a scalable type");
+      return failure();
+    }
+
+    auto module = op->getParentOfType<ModuleOp>();
+    auto *ctx = op.getContext();
+    auto i64 = IntegerType::get(ctx, 64);
+    auto llvmPtr = LLVM::LLVMPointerType::get(ctx);
+    auto functionType = LLVM::LLVMFunctionType::get(llvmPtr, {i64});
+    auto function = module.lookupSymbol<LLVM::LLVMFuncOp>(allocator);
+    if (function) {
+      if (function.getFunctionType() != functionType) {
+        op.emitError(
+            "allocator function has incompatible type; expected ptr(i64)");
+        return failure();
+      }
+    } else {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+      function = LLVM::LLVMFuncOp::create(rewriter, op.getLoc(), allocator,
+                                          functionType);
+    }
+
+    auto sizeValue = LLVM::ConstantOp::create(
+        rewriter, op.getLoc(), i64,
+        rewriter.getI64IntegerAttr(size.getFixedValue()));
+    auto call = LLVM::CallOp::create(rewriter, op.getLoc(), llvmPtr,
+                                     FlatSymbolRefAttr::get(ctx, allocator),
+                                     ValueRange{sizeValue});
+    rewriter.replaceOp(op, call.getResult());
+    return success();
+  }
+
+  std::string allocator;
+};
+
+struct GCIRToLLVMPass
+    : public mlir::impl::BelalangGCIRToLLVMPassBase<GCIRToLLVMPass> {
+  using mlir::impl::BelalangGCIRToLLVMPassBase<
+      GCIRToLLVMPass>::BelalangGCIRToLLVMPassBase;
+
+  void runOnOperation() override {
+    GCIRToLLVMTypeConverter converter(&getContext());
+
+    RewritePatternSet patterns(&getContext());
+    patterns.add<AllocOpLowering>(converter, &getContext(), allocator);
+    populateFuncToLLVMConversionPatterns(converter, patterns);
+
+    ConversionTarget target(getContext());
+    target.addLegalDialect<LLVM::LLVMDialect, BuiltinDialect>();
+    target.addIllegalDialect<GCIRDialect>();
+
+    if (applyFullConversion(getOperation(), target, std::move(patterns))
+            .failed())
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/lib/GCIR/IR/GCIRDialect.cpp
+++ b/lib/GCIR/IR/GCIRDialect.cpp
@@ -7,12 +7,20 @@
 #define GET_TYPEDEF_CLASSES
 #include "belalang/GCIR/IR/GCIRTypes.cpp.inc"
 
+#define GET_OP_CLASSES
+#include "belalang/GCIR/IR/GCIROps.cpp.inc"
+
 namespace belalang::gc {
 
 void GCIRDialect::initialize() {
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "belalang/GCIR/IR/GCIRTypes.cpp.inc"
+      >();
+
+  addOperations<
+#define GET_OP_LIST
+#include "belalang/GCIR/IR/GCIROps.cpp.inc"
       >();
 }
 

--- a/tests/GCIR/Transforms/BUILD.bazel
+++ b/tests/GCIR/Transforms/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//tests:lit.bzl", "lit_test")
+
+lit_test(
+    name = "lit_test",
+    tests = glob(["*.mlir"]),
+    data = [
+        "//tools/bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //tools/bir-opt)",
+    },
+)

--- a/tests/GCIR/Transforms/alloc-to-llvm.mlir
+++ b/tests/GCIR/Transforms/alloc-to-llvm.mlir
@@ -1,0 +1,22 @@
+// RUN: %bir-opt --convert-gcir-to-llvm %s | %FileCheck %s
+// RUN: %bir-opt --convert-gcir-to-llvm='alloc-function=my_alloc' %s | %FileCheck %s --check-prefix=CUSTOM
+
+// CHECK-LABEL: llvm.func @malloc
+// CHECK-SAME: (i64) -> !llvm.ptr
+
+// CHECK-LABEL: llvm.func @test
+// CHECK: %[[SIZE:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK: %[[PTR:.*]] = llvm.call @malloc(%[[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK: llvm.return %[[PTR]] : !llvm.ptr
+
+// CUSTOM-LABEL: llvm.func @my_alloc
+// CUSTOM-SAME: (i64) -> !llvm.ptr
+
+// CUSTOM: llvm.call @my_alloc
+
+module {
+  func.func @test() -> !gc.ptr<i64> {
+    %p = "gc.alloc"() : () -> !gc.ptr<i64>
+    return %p : !gc.ptr<i64>
+  }
+}

--- a/tools/bir-opt/BUILD.bazel
+++ b/tools/bir-opt/BUILD.bazel
@@ -8,7 +8,9 @@ cc_binary(
     deps = [
         "//lib:BIR",
         "//lib:GCIR",
+        "//include:GCIR",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:MlirOptLib",
     ],
 )

--- a/tools/bir-opt/CMakeLists.txt
+++ b/tools/bir-opt/CMakeLists.txt
@@ -3,6 +3,7 @@ target_link_libraries(bir-opt
   PRIVATE
     BelalangBIR
     BelalangGCIR
+    MLIRFuncDialect
     MLIRLLVMDialect
     MLIROptLib
 )

--- a/tools/bir-opt/bir-opt.cpp
+++ b/tools/bir-opt/bir-opt.cpp
@@ -1,6 +1,8 @@
 #include "belalang/BIR/IR/BIR.h"
 #include "belalang/BIR/Passes.h"
 #include "belalang/GCIR/IR/GCIR.h"
+#include "belalang/GCIR/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
@@ -9,10 +11,12 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
   registry.insert<belalang::bir::BIRDialect, belalang::gc::GCIRDialect,
-                  mlir::cf::ControlFlowDialect, mlir::LLVM::LLVMDialect>();
+                  mlir::cf::ControlFlowDialect, mlir::func::FuncDialect,
+                  mlir::LLVM::LLVMDialect>();
 
   belalang::bir::registerPasses();
   belalang::bir::registerBIRPipelines();
+  mlir::registerBelalangGCIRToLLVMPass();
   mlir::registerTransformsPasses();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(


### PR DESCRIPTION
This change implements the AllocOp in gcir and its lowering to LLVM. As of now, gcir requires func dialect.