### PR TITLE
[ci] Cached LLVM build skips LLVM checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,19 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libz-dev libxml2-dev
-      - name: Check out LLVM
-        uses: actions/checkout@v5
-        with:
-          repository: llvm/llvm-project
-          ref: 6716e3108af4eba29b28140d17d1f022eb7adb64
-          path: llvm-project
       - name: Cache LLVM build
         id: llvm-cache
         uses: actions/cache@v4
         with:
           path: llvm-build
           key: llvm-${{ runner.os }}-6716e3108af4eba29b28140d17d1f022eb7adb64-x86-release-v1
+      - name: Check out LLVM
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: llvm/llvm-project
+          ref: 6716e3108af4eba29b28140d17d1f022eb7adb64
+          path: llvm-project
       - name: Build LLVM and MLIR
         if: steps.llvm-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
I saw in #370 that LLVM checkout took 50 seconds, even though the CI didn't need the LLVM checkout as the build was cached. This change makes CI not check out LLVM if LLVM build cache is available, which should speed things slightly up.