### PR TITLE
[chore][tools] Remove unused workspace_status.sh

### DIFF
--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "STABLE_GIT_COMMIT $(git rev-parse HEAD 2>/dev/null || echo unknown)"


### PR DESCRIPTION
This was previously used in the Bazel configuration. We have since moved on to CMake rendering this script unused. This change removes it.