### PR TITLE
[llvmgen][bin] Use llvm::StringRef for function input

### DIFF
--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -267,8 +267,8 @@ int build(muopt::Parser &parser, const BelalangCtx &ctx) {
     }
     Path tempDir = *tempDirRes;
 
-    std::string objFile = pathIn(tempDir, "output.o").str().str();
-    std::string exeFile = executablePathFor(source).str().str();
+    Path objFile = pathIn(tempDir, "output.o");
+    Path exeFile = executablePathFor(source);
 
     llvmgen::LLVMGen llvmgen(birgen.getModulePtr());
     llvmgen.compileObjFile(objFile, llvmgen::SanitizerKind::None);

--- a/bin/belalang/CmdRun.cpp
+++ b/bin/belalang/CmdRun.cpp
@@ -50,8 +50,8 @@ int run(muopt::Parser &parser, const BelalangCtx &ctx) {
   }
   Path tempDir = *tempDirRes;
 
-  std::string objFile = pathIn(tempDir, "output.o").str().str();
-  std::string exeFile = pathIn(tempDir, "output.exe").str().str();
+  Path objFile = pathIn(tempDir, "output.o");
+  Path exeFile = pathIn(tempDir, "output.exe");
 
   llvmgen::LLVMGen llvmgen(birgen.getModulePtr());
   llvmgen.compileObjFile(objFile, llvmgen::SanitizerKind::None);

--- a/include/belalang/LLVMGen/LLVMGen.h
+++ b/include/belalang/LLVMGen/LLVMGen.h
@@ -1,7 +1,7 @@
 #ifndef BELALANG_LLVMGEN_LLVMGEN_H_
 #define BELALANG_LLVMGEN_LLVMGEN_H_
 
-#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include <cstdint>
@@ -21,7 +21,7 @@ public:
   ~LLVMGen() = default;
 
   std::string dumpToString() const;
-  void compileObjFile(std::string outfile, SanitizerKind san) const;
+  void compileObjFile(llvm::StringRef outfile, SanitizerKind san) const;
 
 private:
   llvm::LLVMContext llvmCtx;

--- a/lib/LLVMGen/LLVMGen.cpp
+++ b/lib/LLVMGen/LLVMGen.cpp
@@ -40,7 +40,7 @@ LLVMGen::LLVMGen(uintptr_t ptr) {
   assert(llvmModule && "translation to LLVM IR failed.");
 }
 
-void LLVMGen::compileObjFile(std::string outfile, SanitizerKind san) const {
+void LLVMGen::compileObjFile(llvm::StringRef outfile, SanitizerKind san) const {
   llvm::InitializeAllTargetInfos();
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -89,8 +89,7 @@ void LLVMGen::compileObjFile(std::string outfile, SanitizerKind san) const {
   }
 
   std::error_code ec;
-  llvm::raw_fd_ostream dest(llvm::StringRef(outfile.data(), outfile.size()), ec,
-                            llvm::sys::fs::OF_None);
+  llvm::raw_fd_ostream dest(outfile, ec, llvm::sys::fs::OF_None);
   if (ec)
     return;
 


### PR DESCRIPTION
We should use llvm::StringRef for function arguments as its the boundary.